### PR TITLE
html/tokenizer: rawtext close tag detection should accept optional whitespace before '>' 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 [[package]]
 name = "html"
 version = "0.1.0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "http"

--- a/crates/html/Cargo.toml
+++ b/crates/html/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+memchr = "2"


### PR DESCRIPTION
Resolves #278 