### PR TITLE
perf guard: prevent fallback to “full tree snapshot” per tick

### DIFF
--- a/crates/runtime_parse/Cargo.toml
+++ b/crates/runtime_parse/Cargo.toml
@@ -8,3 +8,6 @@ bus = { path = "../bus" }
 html = { path = "../html", features = ["internal-api"] }
 core_types = { path = "../core_types" }
 tools = { path = "../tools" }
+
+[features]
+patch-stats = []


### PR DESCRIPTION
Resolves #381 