### PR TITLE
eliminate per-token href String clones in InlineContext

### DIFF
--- a/crates/gfx/src/input/route.rs
+++ b/crates/gfx/src/input/route.rs
@@ -905,7 +905,7 @@ mod tests {
         InputId, InputValueStore, SelectionRange, caret_from_x_with_boundaries,
         rebuild_cursor_boundaries,
     };
-    use layout::inline::{InlineActionKind, InlineFragment};
+    use layout::inline::{InlineAction, InlineActionKind, InlineFragment};
     use layout::{
         LayoutBox, Rectangle, TextMeasurer, content_height, content_x_and_width, content_y,
         layout_block_tree,
@@ -1116,8 +1116,12 @@ mod tests {
                             InlineFragment::Box { action, .. } => action,
                             InlineFragment::Replaced { action, .. } => action,
                         };
-                        if let Some((id, InlineActionKind::Link, _)) = action
-                            && *id == link_id
+                        if let Some(InlineAction {
+                            target,
+                            kind: InlineActionKind::Link,
+                            ..
+                        }) = action.as_ref()
+                            && *target == link_id
                         {
                             return Some(frag.rect);
                         }

--- a/crates/layout/src/inline/engine.rs
+++ b/crates/layout/src/inline/engine.rs
@@ -9,7 +9,7 @@ use super::metrics::{
 };
 use super::options::InlineLayoutOptions;
 use super::tokens::{InlineToken, collect_inline_tokens_for_block_layout_for_paint};
-use super::types::{InlineActionKind, InlineFragment, LineBox, LineFragment};
+use super::types::{InlineFragment, LineBox, LineFragment};
 
 // Inline layout pipeline facade used by painting and hit-testing.
 pub fn layout_inline_for_paint<'a>(
@@ -222,9 +222,7 @@ pub(super) fn layout_tokens_with_options<'a>(
                 let ascent = metrics.ascent;
                 let descent = metrics.descent;
 
-                let action = ctx
-                    .link_target
-                    .map(|id| (id, InlineActionKind::Link, ctx.link_href.clone()));
+                let action = ctx.to_action();
 
                 line_fragments.push(LineFragment {
                     kind: InlineFragment::Text {
@@ -267,9 +265,7 @@ pub(super) fn layout_tokens_with_options<'a>(
                 let ascent = metrics.ascent;
                 let descent = metrics.descent;
 
-                let action = ctx
-                    .link_target
-                    .map(|id| (id, InlineActionKind::Link, ctx.link_href.clone()));
+                let action = ctx.to_action();
 
                 let mut remaining_text = text;
                 let mut remaining_source_start = source_range.map(|(s, _e)| s);
@@ -534,9 +530,7 @@ pub(super) fn layout_tokens_with_options<'a>(
                     height: metrics.height(),
                 };
 
-                let action = ctx
-                    .link_target
-                    .map(|id| (id, InlineActionKind::Link, ctx.link_href.clone()));
+                let action = ctx.to_action();
 
                 line_fragments.push(LineFragment {
                     kind: InlineFragment::Box {
@@ -605,9 +599,7 @@ pub(super) fn layout_tokens_with_options<'a>(
                     height: metrics.height(),
                 };
 
-                let action = ctx
-                    .link_target
-                    .map(|id| (id, InlineActionKind::Link, ctx.link_href.clone()));
+                let action = ctx.to_action();
 
                 line_fragments.push(LineFragment {
                     kind: InlineFragment::Replaced {

--- a/crates/layout/src/inline/mod.rs
+++ b/crates/layout/src/inline/mod.rs
@@ -18,4 +18,4 @@ pub(crate) use dom_attrs::get_attr;
 pub use engine::layout_inline_for_paint;
 pub use refine::refine_layout_with_inline;
 pub use textarea::layout_textarea_value_for_paint;
-pub use types::{InlineActionKind, InlineFragment, LineBox, LineFragment};
+pub use types::{InlineAction, InlineActionKind, InlineFragment, LineBox, LineFragment};

--- a/crates/layout/src/inline/types.rs
+++ b/crates/layout/src/inline/types.rs
@@ -1,10 +1,18 @@
 use crate::{LayoutBox, Rectangle, ReplacedKind};
 use css::ComputedStyle;
 use html::internal::Id;
+use std::sync::Arc;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InlineActionKind {
     Link,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InlineAction {
+    pub target: Id,
+    pub kind: InlineActionKind,
+    pub href: Option<Arc<str>>,
 }
 
 /// The logical content carried by a line fragment.
@@ -14,12 +22,12 @@ pub enum InlineFragment<'a> {
     Text {
         text: String,
         style: &'a ComputedStyle,
-        action: Option<(Id, InlineActionKind, Option<String>)>,
+        action: Option<InlineAction>,
     },
     Box {
         /// Style of the inline box (for color, etc.).
         style: &'a ComputedStyle,
-        action: Option<(Id, InlineActionKind, Option<String>)>,
+        action: Option<InlineAction>,
         /// Layout box for this inline-level box, if we have one.
         /// - `Some(..)` in the painting path
         /// - `None` in the height computation path
@@ -28,7 +36,7 @@ pub enum InlineFragment<'a> {
     Replaced {
         style: &'a ComputedStyle,
         kind: ReplacedKind,
-        action: Option<(Id, InlineActionKind, Option<String>)>,
+        action: Option<InlineAction>,
         layout: Option<&'a LayoutBox<'a>>, // usually None; future-proof (e.g. <button>)
     },
 }


### PR DESCRIPTION
Resolves #337 