### PR TITLE
document the CSSOM/rule model contract and retire obsolete internal representations

### DIFF
--- a/crates/css/src/lib.rs
+++ b/crates/css/src/lib.rs
@@ -1,10 +1,20 @@
+//! Public CSS crate surface.
+//!
+//! The crate root is model-first for whole-stylesheet parsing:
+//! `parse_stylesheet(...)` and `parse_stylesheet_with_options(...)` produce the
+//! engine-facing `css::model` parse result.
+//!
+//! Syntax-layer and compatibility-scoped APIs remain available explicitly for
+//! parser work, migration support, and golden tests, but they are no longer the
+//! preferred crate-root contract for new engine-facing CSS code.
+
 pub mod cascade;
 pub mod computed;
 pub mod model;
 pub mod syntax;
 pub mod values;
 
-// Re-exports so other crates can just use `css::...` nicely.
+// Model-first crate-root surface for engine-facing stylesheet work.
 pub use cascade::{attach_styles, get_inline_style, is_css};
 pub use computed::{ComputedStyle, StyledNode, build_style_tree, compute_style};
 pub use model::{
@@ -16,21 +26,45 @@ pub use model::{
     serialize_stylesheet_for_snapshot, serialize_stylesheet_parse_for_snapshot,
     serialize_value_for_snapshot,
 };
+
+// Explicit syntax-layer surface for parser/tokenizer work and syntax tests.
 pub use syntax::{
-    CompatRule, CompatSelector, CompatStylesheet, CssAtRule, CssBlockKind, CssComponentValue,
-    CssDeclaration, CssDeclarationBlock, CssDimension, CssFunction, CssHashKind, CssInput,
-    CssInputId, CssNumber, CssNumericKind, CssParseOrigin, CssPosition, CssQualifiedRule, CssRule,
-    CssSimpleBlock, CssSpan, CssStylesheet, CssToken, CssTokenKind, CssTokenText, CssTokenization,
-    CssTokenizationStats, CssUnicodeRange, Declaration as CompatDeclaration, DeclarationListParse,
-    DiagnosticKind, DiagnosticSeverity, ParseOptions, ParseStats, RecoveryPolicy,
-    StylesheetParse as SyntaxStylesheetParse, SyntaxDiagnostic, SyntaxLimits, parse_declarations,
-    parse_declarations_with_options, parse_stylesheet as parse_syntax_stylesheet,
+    CssAtRule, CssBlockKind, CssComponentValue, CssDeclaration, CssDeclarationBlock, CssDimension,
+    CssFunction, CssHashKind, CssInput, CssInputId, CssNumber, CssNumericKind, CssParseOrigin,
+    CssPosition, CssQualifiedRule, CssRule, CssSimpleBlock, CssSpan, CssStylesheet, CssToken,
+    CssTokenKind, CssTokenText, CssTokenization, CssTokenizationStats, CssUnicodeRange,
+    DeclarationListParse, DiagnosticKind, DiagnosticSeverity, ParseOptions, ParseStats,
+    RecoveryPolicy, StylesheetParse as SyntaxStylesheetParse, SyntaxDiagnostic, SyntaxLimits,
+    parse_declarations, parse_declarations_with_options,
+    parse_stylesheet as parse_syntax_stylesheet,
     parse_stylesheet_with_options as parse_syntax_stylesheet_with_options,
-    serialize_compat_stylesheet_for_snapshot, serialize_declaration_list_parse_for_snapshot,
-    serialize_declarations_for_snapshot,
+    serialize_declaration_list_parse_for_snapshot, serialize_declarations_for_snapshot,
     serialize_stylesheet_for_snapshot as serialize_syntax_stylesheet_for_snapshot,
     serialize_stylesheet_parse_for_snapshot as serialize_syntax_stylesheet_parse_for_snapshot,
     serialize_tokenization_for_snapshot, serialize_tokens_for_snapshot, tokenize_str,
     tokenize_str_with_options,
 };
+
+// Migration-only compatibility surfaces retained for transitional code.
+#[deprecated(
+    note = "CompatRule is migration-only. New engine-facing CSS work should build on css::model::Rule or use css::syntax explicitly when syntax output is required."
+)]
+pub use syntax::CompatRule;
+#[deprecated(
+    note = "CompatSelector is migration-only. New engine-facing CSS work should build on css::model or use css::syntax explicitly when syntax output is required."
+)]
+pub use syntax::CompatSelector;
+#[deprecated(
+    note = "CompatStylesheet is migration-only. Store css::StylesheetParse or css::Stylesheet instead, and keep compatibility projection isolated at the consumer boundary that still needs it."
+)]
+pub use syntax::CompatStylesheet;
+#[deprecated(
+    note = "CompatDeclaration is migration-only. New declaration/value work should build on css::Declaration or use css::syntax explicitly when declaration-list compatibility output is required."
+)]
+pub use syntax::Declaration as CompatDeclaration;
+#[deprecated(
+    note = "Compatibility stylesheet snapshots are migration-only. Prefer the model snapshot serializers for the engine-facing contract."
+)]
+pub use syntax::serialize_compat_stylesheet_for_snapshot;
+
 pub use values::{Display, Length, parse_color, parse_length};

--- a/crates/css/src/syntax/entry.rs
+++ b/crates/css/src/syntax/entry.rs
@@ -4,10 +4,11 @@ use super::{CompatStylesheet, Declaration, DeclarationListParse, ParseOptions, S
 
 /// Compatibility wrapper for callers that still need `CompatStylesheet`.
 ///
-/// New parser work must prefer `parse_stylesheet_with_options(...)` and operate
-/// on `StylesheetParse`. This wrapper exists only as a migration bridge for
-/// compatibility-scoped consumers that have not yet moved off
-/// `CompatStylesheet`.
+/// Within `css::syntax`, new parser work must prefer
+/// `parse_stylesheet_with_options(...)` and operate on `StylesheetParse`. At
+/// the crate root, whole-stylesheet parsing is now model-first through
+/// `css::parse_stylesheet_with_options(...)`; this wrapper remains only for
+/// explicit syntax-layer migration support.
 pub fn parse_stylesheet(input: &str) -> CompatStylesheet {
     parse_stylesheet_with_options(input, &ParseOptions::stylesheet()).to_compat_stylesheet()
 }

--- a/crates/css/src/syntax/results.rs
+++ b/crates/css/src/syntax/results.rs
@@ -39,6 +39,11 @@ impl StylesheetParse {
         serialize_stylesheet_parse_for_snapshot(self)
     }
 
+    /// Migration-only compatibility projection for consumers that still need
+    /// the legacy cascade bridge shape.
+    ///
+    /// New engine-facing stylesheet work must prefer `css::model` as the
+    /// default downstream contract rather than building on this projection.
     pub fn to_compat_stylesheet(&self) -> CompatStylesheet {
         compat::project_stylesheet_to_compat(&self.input, &self.stylesheet)
     }

--- a/docs/css/n8-parser-contract-cutover.md
+++ b/docs/css/n8-parser-contract-cutover.md
@@ -1,6 +1,6 @@
 # N8: Document The CSS Parser Contract And Retire Prototype Parsing Path
 
-Last updated: 2026-04-06  
+Last updated: 2026-04-08  
 Status: implemented
 
 ## Implemented Result
@@ -12,13 +12,16 @@ parser stack is the defined basis for future CSS work, and the product browser
 path no longer treats the compatibility wrappers as the primary stylesheet
 parser interface.
 
-The shipped cutover state is:
+The shipped syntax-layer cutover state is:
 
 - `css::syntax` owns the tokenizer, structured parser, recovery behavior,
   invariants, limits, and stable snapshot surface
-- `parse_stylesheet_with_options(...)` and
-  `parse_declarations_with_options(...)` are the stable structured syntax
-  entrypoints
+- `css::syntax::parse_stylesheet_with_options(...)` and
+  `css::syntax::parse_declarations_with_options(...)` are the stable
+  structured syntax entrypoints
+- crate-root whole-stylesheet parsing is now model-first after Milestone O;
+  explicit syntax access remains available through `css::syntax::...` and root
+  aliases such as `css::parse_syntax_stylesheet_with_options(...)`
 - browser/runtime integration uses the structured parser path and only projects
   into compatibility forms at the cascade boundary
 - compatibility wrappers remain available only as migration bridges for code
@@ -50,10 +53,10 @@ This final issue exists to make the new architecture explicit and durable:
 
 ## Stable API After Cutover
 
-Preferred structured entrypoints:
+Preferred structured syntax entrypoints:
 
-- `parse_stylesheet_with_options(input, options) -> StylesheetParse`
-- `parse_declarations_with_options(input, options) -> DeclarationListParse`
+- `css::syntax::parse_stylesheet_with_options(input, options) -> StylesheetParse`
+- `css::syntax::parse_declarations_with_options(input, options) -> DeclarationListParse`
 - `tokenize_str_with_options(input, options) -> CssTokenization`
 
 Structured stylesheet contract:
@@ -65,8 +68,8 @@ Structured stylesheet contract:
 
 Compatibility bridges that remain intentionally secondary:
 
-- `parse_stylesheet(input) -> CompatStylesheet`
-- `parse_declarations(input) -> Vec<Declaration>`
+- `css::syntax::parse_stylesheet(input) -> CompatStylesheet`
+- `css::syntax::parse_declarations(input) -> Vec<Declaration>`
 - `CompatSelector`, `CompatRule`, `CompatStylesheet`
 
 These compatibility shapes are not the syntax-layer contract and must not be
@@ -87,9 +90,9 @@ Retired from the runtime browser path:
 - direct stylesheet parsing through the compatibility convenience wrapper as the
   default basis for page stylesheet handling
 
-The browser now parses stylesheet text through the structured syntax entrypoint
-and projects to compatibility forms only where the current cascade layer still
-requires them.
+The browser now parses stylesheet text through the structured syntax entrypoint,
+converts it into the engine-facing model, and projects to compatibility forms
+only where the current cascade layer still requires them.
 
 ## Known Deferred Limitations
 

--- a/docs/css/o1-rule-value-model-architecture.md
+++ b/docs/css/o1-rule-value-model-architecture.md
@@ -1,6 +1,6 @@
 # O1: Define CSS Rule/Value Model Architecture And Ownership Strategy
 
-Last updated: 2026-04-07  
+Last updated: 2026-04-08  
 Status: architecture contract implemented
 
 This document is the source-of-truth contract for Milestone O's first issue:
@@ -30,6 +30,7 @@ Related documents:
 - `docs/css/syntax-parser-contract.md`
 - `docs/css/n8-parser-contract-cutover.md`
 - `docs/css/n9-selector-structure-expansion.md`
+- `docs/css/o8-cssom-contract-and-legacy-retirement.md`
 
 ## Implemented Result
 

--- a/docs/css/o7-parser-model-cutover.md
+++ b/docs/css/o7-parser-model-cutover.md
@@ -13,6 +13,10 @@ Related code:
 - `crates/browser/src/page.rs`
 - `crates/css/tests/model_cutover.rs`
 
+Related documents:
+- `docs/css/o6-canonical-model-serialization.md`
+- `docs/css/o8-cssom-contract-and-legacy-retirement.md`
+
 ## Implemented Result
 
 The stylesheet parser pipeline is now model-first:

--- a/docs/css/o8-cssom-contract-and-legacy-retirement.md
+++ b/docs/css/o8-cssom-contract-and-legacy-retirement.md
@@ -1,0 +1,143 @@
+# O8: Document The CSSOM/Rule Model Contract And Retire Obsolete Internal Representations
+
+Last updated: 2026-04-08  
+Status: implemented
+
+This document closes Milestone O by making the engine-facing CSS
+stylesheet/rule/declaration/value model the explicit repository contract and by
+isolating the remaining legacy compatibility surfaces.
+
+Related code:
+- `crates/css/src/lib.rs`
+- `crates/css/src/model/mod.rs`
+- `crates/css/src/model/entry.rs`
+- `crates/css/src/model/serialize.rs`
+- `crates/css/src/cascade.rs`
+- `crates/css/src/syntax/mod.rs`
+- `crates/css/src/syntax/results.rs`
+- `crates/browser/src/page.rs`
+
+Related documents:
+- `docs/css/o1-rule-value-model-architecture.md`
+- `docs/css/o6-canonical-model-serialization.md`
+- `docs/css/o7-parser-model-cutover.md`
+- `docs/css/syntax-parser-contract.md`
+
+## Implemented Result
+
+Milestone O is now complete as a repository contract and implementation state:
+
+- the crate-root stylesheet parse API is model-first
+- the browser stores model parse artifacts as stylesheet state
+- the engine-facing stylesheet/rule/declaration/value model is documented as
+  the default handoff into later selector and cascade work
+- ownership, span/debug-span, and snapshot expectations are documented across
+  the model docs and Milestone O contract documents
+- compatibility-scoped stylesheet and raw-string declaration surfaces are
+  isolated as explicit migration APIs rather than looking like the preferred
+  contract
+
+## Default Contract After Milestone O
+
+Future engine-facing CSS work should treat these as the normative contract:
+
+- `css::parse_stylesheet(...) -> css::Stylesheet`
+- `css::parse_stylesheet_with_options(...) -> css::StylesheetParse`
+- `css::Stylesheet`
+- `css::Rule`
+- `css::Declaration`
+- `css::DeclarationValue`
+- `css::serialize_stylesheet_for_snapshot(...)`
+- `css::serialize_stylesheet_parse_for_snapshot(...)`
+
+This is the stable stylesheet handoff layer for:
+
+- selector AST refinement
+- selector matching
+- cascade precedence and winner resolution
+- specified/computed value work
+- diagnostics and future CSS tooling
+
+## Ownership, Span, And Serialization Expectations
+
+Milestone O established and implemented these durable expectations:
+
+- the model owns long-lived stylesheet/rule/declaration/value data
+- parser-local scratch data is not borrowed by the model contract
+- structural nodes carry direct source spans
+- text/helper payloads carry optional debug spans where appropriate
+- canonicalization is limited to model-owned identity rules such as
+  case-insensitive property and at-rule names
+- snapshot/debug output is explicit, versioned, deterministic, and aligned with
+  the model rather than authored CSS pretty-printing
+
+The authoritative details live in:
+
+- `docs/css/o1-rule-value-model-architecture.md`
+- `docs/css/o6-canonical-model-serialization.md`
+
+## What Remains Intentionally Deferred
+
+Milestone O does not complete later CSS semantics. The following remain
+intentional follow-up work:
+
+- selector AST expansion beyond preserved selector/prelude payloads
+- selector matching beyond the current compatibility-scoped subset
+- at-rule semantic interpretation
+- cascade winner resolution that natively consumes model selectors/values
+- property-specific specified-value parsing
+- computed-style generation on top of the model without the current string-based
+  bridge
+- full inline `style=""` migration away from compatibility-scoped raw-string
+  declarations
+
+Those are not gaps in the model contract. They are later-layer semantics that
+must build on the model instead of bypassing it.
+
+## Obsolete And Transitional Representations
+
+The following surfaces remain in-repo only as explicit migration boundaries:
+
+- `css::syntax::CompatSelector`
+- `css::syntax::CompatRule`
+- `css::syntax::CompatStylesheet`
+- `css::syntax::Declaration { name: String, value: String }`
+- `css::syntax::parse_stylesheet(...)`
+- `css::syntax::parse_declarations(...)`
+- `StylesheetParse::to_compat_stylesheet()`
+
+Retirement/isolation policy:
+
+- these compatibility surfaces are not the engine-facing contract
+- new engine-facing CSS work must not store them as primary stylesheet state
+- new parser integration must not route through them to reach the model
+- crate-root compatibility re-exports are now explicitly marked as
+  migration-only
+- compatibility projection belongs only at the consumer boundary that still
+  needs it
+
+Current remaining compatibility boundary:
+
+- `css::cascade` derives its temporary compatibility view from model parse
+  artifacts at attachment time
+
+## Contributor Guidance
+
+When working on later CSS milestones:
+
+- start from `css::StylesheetParse` / `css::Stylesheet`
+- use `css::syntax::...` only when you are intentionally doing syntax-layer
+  work
+- treat compat/raw-string surfaces as transitional adapters to be reduced, not
+  extended
+- update model snapshots and fixtures when model-grammar changes are intended
+- do not introduce new raw-string stylesheet/value storage as a normative path
+
+## Exit Criteria
+
+- the CSSOM/rule/value model contract is documented in-repository
+- ownership/span/serialization expectations are documented and linked
+- obsolete compatibility/raw-string assumptions are isolated from the preferred
+  crate-root contract
+- future contributors can continue into selector and cascade milestones without
+  ambiguity about the model handoff

--- a/docs/css/syntax-parser-contract.md
+++ b/docs/css/syntax-parser-contract.md
@@ -1,13 +1,13 @@
 # CSS Syntax Layer Contract (Milestone N)
 
-Last updated: 2026-04-07  
+Last updated: 2026-04-08  
 Scope: `crates/css/src/syntax/mod.rs`, `crates/css/src/syntax/compat.rs`,
 `crates/css/src/syntax/input.rs`, `crates/css/src/syntax/token.rs`,
 `crates/css/src/syntax/serialize.rs`,
 `crates/css/src/syntax/tokenizer/mod.rs`,
 `crates/css/src/syntax/parser/mod.rs`,
-`crates/runtime_css/src/lib.rs`, and the
-current browser integration path in `crates/browser/src/page.rs`
+`crates/runtime_css/src/lib.rs`, and the explicit syntax-layer access paths
+used by tests and migration code
 
 This document is the source-of-truth contract for Milestone N's CSS syntax
 layer. It defines what the tokenizer and parser own, what malformed-input
@@ -16,6 +16,7 @@ replaced, and what downstream milestones may assume.
 
 Related downstream contract:
 - `docs/css/o1-rule-value-model-architecture.md`
+- `docs/css/o8-cssom-contract-and-legacy-retirement.md`
 
 Related code:
 - `crates/css/src/syntax/mod.rs`
@@ -174,10 +175,20 @@ It MUST NOT:
 
 ## Entry Points And Expected Outputs
 
-Milestone N defines two syntax entry points:
+Milestone N's syntax entry points are now explicit syntax-layer APIs:
 
-- `parse_stylesheet_with_options(input, options) -> StylesheetParse`
-- `parse_declarations_with_options(input, options) -> DeclarationListParse`
+- `css::syntax::parse_stylesheet_with_options(input, options) -> StylesheetParse`
+- `css::syntax::parse_declarations_with_options(input, options) -> DeclarationListParse`
+
+After Milestone O's parser/model cutover, crate-root whole-stylesheet parsing
+is no longer the syntax-layer default. The root stylesheet entrypoints now
+produce the engine-facing model parse result. Explicit syntax-layer access
+remains available through:
+
+- `css::syntax::parse_stylesheet_with_options(...)`
+- `css::parse_syntax_stylesheet_with_options(...)`
+- `css::syntax::parse_stylesheet(...)`
+- `css::parse_syntax_stylesheet(...)`
 
 The parser result contract is:
 
@@ -191,10 +202,10 @@ The parser result contract is:
   - total diagnostics emitted
   - whether a configured limit was hit
 
-Compatibility wrappers remain available:
+Compatibility wrappers remain available within the syntax layer:
 
-- `parse_stylesheet(input) -> CompatStylesheet`
-- `parse_declarations(input) -> Vec<Declaration>`
+- `css::syntax::parse_stylesheet(input) -> CompatStylesheet`
+- `css::syntax::parse_declarations(input) -> Vec<Declaration>`
 
 Downstream code may keep using these wrappers during migration, but they are
 compatibility bridges only. New parser work must target the structured
@@ -209,7 +220,8 @@ Current stylesheet parse shape:
   - parse stats
 - compatibility projection is explicit:
   - `StylesheetParse::to_compat_stylesheet()`
-  - `parse_stylesheet(input)` remains a migration convenience wrapper
+  - `css::syntax::parse_stylesheet(input)` remains a migration convenience
+    wrapper
 
 ## Handoff To Milestone O
 
@@ -217,6 +229,8 @@ Milestone N ends at syntax-layer structure. The next stable handoff is the
 engine-facing CSS rule/value model defined in:
 
 - `docs/css/o1-rule-value-model-architecture.md`
+- `docs/css/o7-parser-model-cutover.md`
+- `docs/css/o8-cssom-contract-and-legacy-retirement.md`
 
 That downstream model consumes syntax-layer output and may canonicalize names or
 normalize value structure where appropriate, but those responsibilities do not


### PR DESCRIPTION
Resolves #768 