### PR TITLE
strengthen width and height resolution for the supported subset

### DIFF
--- a/crates/layout/src/box_tree/tests/projection.rs
+++ b/crates/layout/src/box_tree/tests/projection.rs
@@ -199,6 +199,132 @@ fn layout_clamps_atomic_inline_width_to_available_content_space() {
 }
 
 #[test]
+fn layout_uses_intrinsic_width_for_auto_inline_block_content() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        Vec::new(),
+        vec![element(
+            3,
+            "span",
+            vec![
+                ("display", "inline-block"),
+                ("padding-left", "5px"),
+                ("padding-right", "7px"),
+            ],
+            vec![text(4, "wide")],
+        )],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let inline_block =
+        find_layout_by_direct_node_id(&layout, Id(3)).expect("inline-block layout box");
+
+    assert_eq!(inline_block.rect.width, 44.0);
+    assert_eq!(inline_block.content_x_and_width(), (5.0, 32.0));
+}
+
+#[test]
+fn intrinsic_auto_inline_block_applies_replaced_control_padding_once() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        Vec::new(),
+        vec![element(
+            3,
+            "span",
+            vec![("display", "inline-block")],
+            vec![element(
+                4,
+                "button",
+                vec![
+                    ("padding-left", "20px"),
+                    ("padding-right", "30px"),
+                    ("font-size", "16px"),
+                ],
+                vec![text(5, "go")],
+            )],
+        )],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let inline_block =
+        find_layout_by_direct_node_id(&layout, Id(3)).expect("inline-block layout box");
+
+    // TestMeasurer: "go" = 16px, button internal chrome = 18px,
+    // button intrinsic content width = 34px, CSS padding = 20 + 30,
+    // outer inline-block content width = 84px.
+    assert_eq!(inline_block.rect.width, 84.0);
+    assert_eq!(inline_block.content_x_and_width(), (0.0, 84.0));
+}
+
+#[test]
+fn layout_shrink_to_fits_auto_inline_block_between_min_and_max_content() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        Vec::new(),
+        vec![element(
+            3,
+            "span",
+            vec![("display", "inline-block")],
+            vec![text(4, "hello world")],
+        )],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 60.0, &TestMeasurer, None);
+    let inline_block =
+        find_layout_by_direct_node_id(&layout, Id(3)).expect("inline-block layout box");
+
+    assert_eq!(inline_block.rect.width, 60.0);
+    assert_eq!(inline_block.content_x_and_width(), (0.0, 60.0));
+}
+
+#[test]
+fn layout_applies_max_width_after_intrinsic_auto_inline_block_width() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        Vec::new(),
+        vec![element(
+            3,
+            "span",
+            vec![("display", "inline-block"), ("max-width", "50px")],
+            vec![text(4, "hello world")],
+        )],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let inline_block =
+        find_layout_by_direct_node_id(&layout, Id(3)).expect("inline-block layout box");
+
+    assert_eq!(inline_block.rect.width, 50.0);
+    assert_eq!(inline_block.content_x_and_width(), (0.0, 50.0));
+}
+
+#[test]
+fn layout_explicit_inline_block_width_overrides_intrinsic_content_width() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        Vec::new(),
+        vec![element(
+            3,
+            "span",
+            vec![("display", "inline-block"), ("width", "100px")],
+            vec![text(4, "wide")],
+        )],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let inline_block =
+        find_layout_by_direct_node_id(&layout, Id(3)).expect("inline-block layout box");
+
+    assert_eq!(inline_block.rect.width, 100.0);
+    assert_eq!(inline_block.content_x_and_width(), (0.0, 100.0));
+}
+
+#[test]
 fn layout_projection_preserves_containing_block_metadata() {
     let dom = doc(vec![element(
         2,

--- a/crates/layout/src/box_tree/tests/projection.rs
+++ b/crates/layout/src/box_tree/tests/projection.rs
@@ -29,6 +29,176 @@ fn layout_projection_accepts_anonymous_boxes_as_layout_participants() {
 }
 
 #[test]
+fn anonymous_layout_boxes_do_not_inherit_anchor_padding_for_sizing() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        vec![
+            ("width", "200px"),
+            ("padding-left", "10px"),
+            ("padding-right", "10px"),
+        ],
+        vec![
+            text(3, "before"),
+            element(4, "p", Vec::new(), vec![text(5, "block")]),
+        ],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let div = find_layout_by_direct_node_id(&layout, Id(2)).expect("div layout box");
+    let anonymous = &div.children[0];
+
+    assert!(anonymous.is_anonymous());
+    assert_eq!(div.content_x_and_width(), (10.0, 200.0));
+    assert_eq!(anonymous.rect.x, 10.0);
+    assert_eq!(anonymous.rect.width, 200.0);
+    assert_eq!(anonymous.content_x_and_width(), (10.0, 200.0));
+}
+
+#[test]
+fn layout_resolves_explicit_width_as_content_box_with_padding() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        vec![
+            ("width", "100px"),
+            ("padding-left", "10px"),
+            ("padding-right", "15px"),
+        ],
+        Vec::new(),
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let div = find_layout_by_direct_node_id(&layout, Id(2)).expect("div layout box");
+
+    assert_eq!(div.rect.width, 125.0);
+    assert_eq!(div.content_x_and_width(), (10.0, 100.0));
+}
+
+#[test]
+fn layout_resolves_auto_width_as_available_border_box_after_padding() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        vec![("padding-left", "10px"), ("padding-right", "15px")],
+        Vec::new(),
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 200.0, &TestMeasurer, None);
+    let div = find_layout_by_direct_node_id(&layout, Id(2)).expect("div layout box");
+
+    assert_eq!(div.rect.width, 200.0);
+    assert_eq!(div.content_x_and_width(), (10.0, 175.0));
+}
+
+#[test]
+fn layout_applies_max_width_to_content_box_before_padding() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        vec![
+            ("width", "200px"),
+            ("max-width", "120px"),
+            ("padding-left", "10px"),
+            ("padding-right", "10px"),
+        ],
+        Vec::new(),
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let div = find_layout_by_direct_node_id(&layout, Id(2)).expect("div layout box");
+
+    assert_eq!(div.rect.width, 140.0);
+    assert_eq!(div.content_x_and_width(), (10.0, 120.0));
+}
+
+#[test]
+fn layout_applies_min_width_to_content_box_before_padding() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        vec![
+            ("width", "80px"),
+            ("min-width", "120px"),
+            ("padding-left", "10px"),
+            ("padding-right", "10px"),
+        ],
+        Vec::new(),
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let div = find_layout_by_direct_node_id(&layout, Id(2)).expect("div layout box");
+
+    assert_eq!(div.rect.width, 140.0);
+    assert_eq!(div.content_x_and_width(), (10.0, 120.0));
+}
+
+#[test]
+fn layout_resolves_explicit_height_as_content_box_with_padding() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        vec![
+            ("height", "40px"),
+            ("padding-top", "5px"),
+            ("padding-bottom", "7px"),
+        ],
+        vec![text(3, "ignored by explicit height")],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let div = find_layout_by_direct_node_id(&layout, Id(2)).expect("div layout box");
+
+    assert_eq!(div.rect.height, 52.0);
+    assert_eq!(div.content_height(), 40.0);
+}
+
+#[test]
+fn layout_derives_nested_auto_width_from_parent_content_box() {
+    let dom = doc(vec![element(
+        2,
+        "section",
+        vec![
+            ("width", "200px"),
+            ("padding-left", "10px"),
+            ("padding-right", "10px"),
+        ],
+        vec![element(3, "div", Vec::new(), Vec::new())],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 500.0, &TestMeasurer, None);
+    let section = find_layout_by_direct_node_id(&layout, Id(2)).expect("section layout box");
+    let div = find_layout_by_direct_node_id(&layout, Id(3)).expect("div layout box");
+
+    assert_eq!(section.rect.width, 220.0);
+    assert_eq!(section.content_x_and_width(), (10.0, 200.0));
+    assert_eq!(div.rect.x, 10.0);
+    assert_eq!(div.rect.width, 200.0);
+}
+
+#[test]
+fn layout_clamps_atomic_inline_width_to_available_content_space() {
+    let dom = doc(vec![element(
+        2,
+        "div",
+        Vec::new(),
+        vec![element(
+            3,
+            "span",
+            vec![("display", "inline-block"), ("width", "200px")],
+            vec![text(4, "atomic")],
+        )],
+    )]);
+    let styled = css::build_style_tree(&dom, None);
+    let layout = crate::layout_block_tree(&styled, 100.0, &TestMeasurer, None);
+    let inline_block =
+        find_layout_by_direct_node_id(&layout, Id(3)).expect("inline-block layout box");
+
+    assert_eq!(inline_block.rect.width, 100.0);
+    assert_eq!(inline_block.content_x_and_width(), (0.0, 100.0));
+}
+
+#[test]
 fn layout_projection_preserves_containing_block_metadata() {
     let dom = doc(vec![element(
         2,

--- a/crates/layout/src/inline/intrinsic.rs
+++ b/crates/layout/src/inline/intrinsic.rs
@@ -1,0 +1,398 @@
+use css::{ComputedStyle, Length};
+use html::Node;
+
+use crate::{
+    AspectRatio, BlockFormattingParticipation, BoxKind, CssPx, InlineFormattingParticipation,
+    IntrinsicSizes, LayoutBox, ReplacedKind, TextMeasurer,
+};
+
+use super::{
+    button::button_label_from_layout,
+    dom_attrs::{get_attr, img_intrinsic_from_dom},
+};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct InlineContributions {
+    min_content: CssPx,
+    max_content: CssPx,
+}
+
+impl InlineContributions {
+    const ZERO: Self = Self {
+        min_content: CssPx::ZERO,
+        max_content: CssPx::ZERO,
+    };
+
+    fn new(min_content: CssPx, max_content: CssPx) -> Self {
+        debug_assert!(max_content >= min_content);
+        Self {
+            min_content,
+            max_content,
+        }
+    }
+
+    fn from_unbreakable(width: CssPx) -> Self {
+        Self::new(width, width)
+    }
+
+    fn max_with(self, other: Self) -> Self {
+        Self::new(
+            css_px_max(self.min_content, other.min_content),
+            css_px_max(self.max_content, other.max_content),
+        )
+    }
+}
+
+pub(super) fn intrinsic_sizes_for_layout_box(
+    measurer: &dyn TextMeasurer,
+    node: &LayoutBox<'_, '_>,
+) -> IntrinsicSizes {
+    match intrinsic_contributions_for_layout_box(measurer, node) {
+        InlineContributions::ZERO => IntrinsicSizes::zero(),
+        contributions => IntrinsicSizes::new(
+            contributions.min_content,
+            contributions.max_content,
+            Some(contributions.max_content),
+            intrinsic_preferred_block_size(measurer, node),
+            intrinsic_aspect_ratio(node),
+        )
+        .expect("intrinsic contribution builder preserves min <= max"),
+    }
+}
+
+fn intrinsic_contributions_for_layout_box(
+    measurer: &dyn TextMeasurer,
+    node: &LayoutBox<'_, '_>,
+) -> InlineContributions {
+    match node.node.node {
+        Node::Text { text, .. } => text_intrinsic_contributions(measurer, text, node.style),
+        Node::Comment { .. } => InlineContributions::ZERO,
+        Node::Document { .. } | Node::Element { .. } => {
+            if matches!(node.kind, BoxKind::ReplacedInline) {
+                return replaced_intrinsic_contributions(measurer, node);
+            }
+
+            let inline = if node.establishes_inline_formatting_context() {
+                inline_formatting_context_intrinsic_contributions(measurer, node)
+            } else {
+                InlineContributions::ZERO
+            };
+
+            let block_children = node
+                .children
+                .iter()
+                .filter(|child| !participates_in_parent_inline_flow(child))
+                .fold(InlineContributions::ZERO, |acc, child| {
+                    acc.max_with(outer_intrinsic_contribution(measurer, child))
+                });
+
+            inline.max_with(block_children)
+        }
+    }
+}
+
+fn inline_formatting_context_intrinsic_contributions(
+    measurer: &dyn TextMeasurer,
+    node: &LayoutBox<'_, '_>,
+) -> InlineContributions {
+    let mut collector = InlineContributionCollector::default();
+    for child in &node.children {
+        collect_inline_contributions(measurer, child, &mut collector);
+    }
+    collector.finish()
+}
+
+fn collect_inline_contributions(
+    measurer: &dyn TextMeasurer,
+    node: &LayoutBox<'_, '_>,
+    collector: &mut InlineContributionCollector,
+) {
+    match node.node.node {
+        Node::Text { text, .. } => {
+            debug_assert_eq!(
+                node.inline_formatting_participation(),
+                InlineFormattingParticipation::TextRun
+            );
+            collector.push_text(measurer, text, node.style);
+        }
+        Node::Comment { .. } => collector.reset_pending_space(),
+        Node::Document { .. } | Node::Element { .. } => {
+            match node.inline_formatting_participation() {
+                InlineFormattingParticipation::InlineContainer => {
+                    for child in &node.children {
+                        collect_inline_contributions(measurer, child, collector);
+                    }
+                }
+                InlineFormattingParticipation::AtomicInline => {
+                    collector.flush_pending_space();
+                    collector.push_atomic(outer_intrinsic_contribution(measurer, node));
+                }
+                InlineFormattingParticipation::None => collector.reset_pending_space(),
+                InlineFormattingParticipation::TextRun => {
+                    debug_assert!(
+                        false,
+                        "text-run inline participation should be represented by text nodes"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct InlineContributionCollector {
+    max_content: f32,
+    min_content: f32,
+    pending_space_width: Option<f32>,
+    has_emitted_content: bool,
+}
+
+impl InlineContributionCollector {
+    fn push_text(&mut self, measurer: &dyn TextMeasurer, text: &str, style: &ComputedStyle) {
+        let mut current_word = String::new();
+
+        for ch in text.chars() {
+            if is_html_ascii_whitespace(ch) {
+                self.flush_word(measurer, &mut current_word, style);
+                if self.pending_space_width.is_none() {
+                    self.pending_space_width = Some(non_negative_measure(measurer, " ", style));
+                }
+            } else {
+                self.flush_pending_space();
+                current_word.push(ch);
+            }
+        }
+
+        self.flush_word(measurer, &mut current_word, style);
+    }
+
+    fn push_atomic(&mut self, contribution: InlineContributions) {
+        self.flush_pending_space();
+        let width = contribution.max_content.get();
+        self.max_content += width;
+        self.min_content = self.min_content.max(contribution.min_content.get());
+        self.has_emitted_content = true;
+    }
+
+    fn flush_word(
+        &mut self,
+        measurer: &dyn TextMeasurer,
+        current_word: &mut String,
+        style: &ComputedStyle,
+    ) {
+        if current_word.is_empty() {
+            return;
+        }
+
+        let width = non_negative_measure(measurer, current_word, style);
+        self.max_content += width;
+        self.min_content = self.min_content.max(width);
+        self.has_emitted_content = true;
+        current_word.clear();
+    }
+
+    fn flush_pending_space(&mut self) {
+        if let Some(space_width) = self.pending_space_width.take() {
+            if self.has_emitted_content {
+                self.max_content += space_width;
+            } else {
+                self.pending_space_width = Some(space_width);
+            }
+        }
+    }
+
+    fn reset_pending_space(&mut self) {
+        self.pending_space_width = None;
+    }
+
+    fn finish(mut self) -> InlineContributions {
+        self.reset_pending_space();
+        InlineContributions::new(
+            css_px(self.min_content),
+            css_px(self.max_content.max(self.min_content)),
+        )
+    }
+}
+
+fn text_intrinsic_contributions(
+    measurer: &dyn TextMeasurer,
+    text: &str,
+    style: &ComputedStyle,
+) -> InlineContributions {
+    let mut collector = InlineContributionCollector::default();
+    collector.push_text(measurer, text, style);
+    collector.finish()
+}
+
+fn outer_intrinsic_contribution(
+    measurer: &dyn TextMeasurer,
+    node: &LayoutBox<'_, '_>,
+) -> InlineContributions {
+    let content = intrinsic_contributions_for_layout_box(measurer, node);
+    let metrics = node.style.box_metrics();
+    let horizontal_edges = metrics.padding_left
+        + metrics.padding_right
+        + metrics.margin_left.max(0.0)
+        + metrics.margin_right.max(0.0);
+    let edges = css_px(horizontal_edges);
+
+    InlineContributions::new(
+        css_px_sum(content.min_content, edges),
+        css_px_sum(content.max_content, edges),
+    )
+}
+
+fn replaced_intrinsic_contributions(
+    measurer: &dyn TextMeasurer,
+    node: &LayoutBox<'_, '_>,
+) -> InlineContributions {
+    let kind = node
+        .replaced
+        .expect("ReplacedInline layout box must carry replaced kind");
+    let width = match kind {
+        ReplacedKind::Img => {
+            let intrinsic = node
+                .replaced_intrinsic
+                .unwrap_or_else(|| img_intrinsic_from_dom(node.node.node));
+            intrinsic.width.unwrap_or(300.0)
+        }
+        ReplacedKind::InputText => {
+            let size_chars = get_attr(node.node.node, "size")
+                .and_then(|s| s.trim().parse::<u32>().ok())
+                .filter(|n| *n > 0)
+                .unwrap_or(20);
+            let avg_char_w = non_negative_measure(measurer, "0", node.style).max(4.0);
+            (size_chars as f32) * avg_char_w + 8.0
+        }
+        ReplacedKind::TextArea => {
+            let cols = get_attr(node.node.node, "cols")
+                .and_then(|s| s.trim().parse::<u32>().ok())
+                .filter(|n| *n > 0)
+                .unwrap_or(20);
+            let avg_char_w = non_negative_measure(measurer, "0", node.style).max(4.0);
+            (cols as f32) * avg_char_w + 8.0
+        }
+        ReplacedKind::InputCheckbox | ReplacedKind::InputRadio => {
+            let Length::Px(font_px) = node.style.font_size();
+            font_px.max(12.0)
+        }
+        ReplacedKind::Button => {
+            let label = button_label_from_layout(node);
+            let text_w = non_negative_measure(measurer, &label, node.style);
+            // UA-like internal control chrome, not author CSS padding. CSS
+            // padding is applied later by the content-box sizing model.
+            (text_w + 18.0).max(24.0)
+        }
+    };
+
+    InlineContributions::from_unbreakable(css_px(width))
+}
+
+fn intrinsic_preferred_block_size(
+    measurer: &dyn TextMeasurer,
+    node: &LayoutBox<'_, '_>,
+) -> Option<CssPx> {
+    match node.node.node {
+        Node::Text { text, .. } if !text.is_empty() => {
+            Some(css_px(non_negative_line_height(measurer, node.style)))
+        }
+        Node::Element { .. } if matches!(node.kind, BoxKind::ReplacedInline) => {
+            replaced_preferred_block_size(measurer, node)
+        }
+        _ => None,
+    }
+}
+
+fn replaced_preferred_block_size(
+    measurer: &dyn TextMeasurer,
+    node: &LayoutBox<'_, '_>,
+) -> Option<CssPx> {
+    let kind = node
+        .replaced
+        .expect("ReplacedInline layout box must carry replaced kind");
+    let height = match kind {
+        ReplacedKind::Img => {
+            let intrinsic = node
+                .replaced_intrinsic
+                .unwrap_or_else(|| img_intrinsic_from_dom(node.node.node));
+            intrinsic.height.or_else(|| {
+                let width = intrinsic.width?;
+                let ratio = intrinsic.ratio?;
+                Some(width / ratio)
+            })
+        }
+        ReplacedKind::InputText => Some(non_negative_line_height(measurer, node.style).max(18.0)),
+        ReplacedKind::TextArea => {
+            let rows = get_attr(node.node.node, "rows")
+                .and_then(|s| s.trim().parse::<u32>().ok())
+                .filter(|n| *n > 0)
+                .unwrap_or(2);
+            Some(((rows as f32) * non_negative_line_height(measurer, node.style)).max(36.0))
+        }
+        ReplacedKind::InputCheckbox | ReplacedKind::InputRadio => {
+            let Length::Px(font_px) = node.style.font_size();
+            Some(font_px.max(12.0))
+        }
+        ReplacedKind::Button => {
+            // UA-like internal control chrome, not author CSS padding.
+            Some((non_negative_line_height(measurer, node.style) + 10.0).max(18.0))
+        }
+    };
+
+    height.map(css_px)
+}
+
+fn intrinsic_aspect_ratio(node: &LayoutBox<'_, '_>) -> Option<AspectRatio> {
+    if !matches!(node.kind, BoxKind::ReplacedInline) {
+        return None;
+    }
+
+    let intrinsic = node.replaced_intrinsic?;
+    intrinsic.ratio.and_then(AspectRatio::new)
+}
+
+fn participates_in_parent_inline_flow(node: &LayoutBox<'_, '_>) -> bool {
+    matches!(
+        node.block_formatting_participation(),
+        BlockFormattingParticipation::InlineLevel | BlockFormattingParticipation::AtomicInline
+    )
+}
+
+fn is_html_ascii_whitespace(ch: char) -> bool {
+    matches!(ch, ' ' | '\n' | '\t' | '\r' | '\u{0C}')
+}
+
+fn non_negative_measure(measurer: &dyn TextMeasurer, text: &str, style: &ComputedStyle) -> f32 {
+    let width = measurer.measure(text, style);
+    if width.is_finite() && width > 0.0 {
+        width
+    } else {
+        0.0
+    }
+}
+
+fn non_negative_line_height(measurer: &dyn TextMeasurer, style: &ComputedStyle) -> f32 {
+    let height = measurer.line_height(style);
+    if height.is_finite() && height > 0.0 {
+        height
+    } else {
+        0.0
+    }
+}
+
+fn css_px(value: f32) -> CssPx {
+    let value = if value.is_finite() {
+        value.max(0.0)
+    } else {
+        0.0
+    };
+    CssPx::new(value).expect("normalized intrinsic measurement is non-negative finite CSS px")
+}
+
+fn css_px_sum(a: CssPx, b: CssPx) -> CssPx {
+    CssPx::new(a.get() + b.get()).expect("sum of finite non-negative CSS px values is valid")
+}
+
+fn css_px_max(a: CssPx, b: CssPx) -> CssPx {
+    if a >= b { a } else { b }
+}

--- a/crates/layout/src/inline/mod.rs
+++ b/crates/layout/src/inline/mod.rs
@@ -3,6 +3,7 @@ mod button;
 mod dom_attrs;
 mod engine;
 mod geometry;
+mod intrinsic;
 mod metrics;
 mod options;
 mod refine;

--- a/crates/layout/src/inline/refine.rs
+++ b/crates/layout/src/inline/refine.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 use super::engine::layout_tokens;
+use super::intrinsic::intrinsic_sizes_for_layout_box;
 use super::options::INLINE_PADDING;
 use super::replaced::size_replaced_inline_children;
 use super::tokens::collect_inline_tokens_for_block_layout;
@@ -36,7 +37,7 @@ fn recompute_block_heights<'style_tree, 'dom>(
     node.rect.y = y;
 
     let mode = normal_flow_sizing_mode(node);
-    let sizing_input = size_resolution_input_for_layout_box(node, available_width);
+    let sizing_input = size_resolution_input_for_layout_box(measurer, node, available_width);
     let inline_size = resolve_normal_flow_inline_size(sizing_input, mode);
     let used_width = inline_size.border().get();
     node.rect.width = used_width;
@@ -244,6 +245,7 @@ fn normal_flow_sizing_mode(node: &LayoutBox<'_, '_>) -> NormalFlowSizingMode {
 }
 
 fn size_resolution_input_for_layout_box(
+    measurer: &dyn TextMeasurer,
     node: &LayoutBox<'_, '_>,
     available_width: f32,
 ) -> SizeResolutionInput {
@@ -261,7 +263,13 @@ fn size_resolution_input_for_layout_box(
             .expect("computed style must materialize deterministic sizing inputs")
     };
 
-    SizeResolutionInput::new(constraint_space, style, IntrinsicSizes::zero())
+    let intrinsic = if node.is_anonymous() {
+        IntrinsicSizes::zero()
+    } else {
+        intrinsic_sizes_for_layout_box(measurer, node)
+    };
+
+    SizeResolutionInput::new(constraint_space, style, intrinsic)
 }
 
 fn resolve_border_block_size(

--- a/crates/layout/src/inline/refine.rs
+++ b/crates/layout/src/inline/refine.rs
@@ -1,7 +1,11 @@
-use css::{ComputedStyle, Display, Length};
+use css::Display;
 use html::Node;
 
-use crate::{BlockFormattingParticipation, BoxKind, LayoutBox, Rectangle, TextMeasurer};
+use crate::{
+    AvailableSize, BlockFormattingParticipation, BoxKind, ConstraintSpace, CssPx, IntrinsicSizes,
+    LayoutBox, NormalFlowSizingMode, Rectangle, SizeResolutionInput, StyleSizeInputs, TextMeasurer,
+    resolve_normal_flow_block_size, resolve_normal_flow_inline_size,
+};
 
 use super::engine::layout_tokens;
 use super::options::INLINE_PADDING;
@@ -31,7 +35,10 @@ fn recompute_block_heights<'style_tree, 'dom>(
     node.rect.x = x;
     node.rect.y = y;
 
-    let used_width = resolve_used_width_for_layout_box(node, available_width);
+    let mode = normal_flow_sizing_mode(node);
+    let sizing_input = size_resolution_input_for_layout_box(node, available_width);
+    let inline_size = resolve_normal_flow_inline_size(sizing_input, mode);
+    let used_width = inline_size.border().get();
     node.rect.width = used_width;
 
     match node.node.node {
@@ -53,7 +60,7 @@ fn recompute_block_heights<'style_tree, 'dom>(
                 cursor_y += h + bm.margin_bottom;
             }
 
-            let height = cursor_y - y;
+            let height = resolve_border_block_size(node, sizing_input, mode, cursor_y - y);
             node.rect.height = height;
             height
         }
@@ -102,14 +109,12 @@ fn recompute_block_heights<'style_tree, 'dom>(
                     cursor_y += h + bm.margin_bottom;
                 }
 
-                let height = cursor_y - y;
+                let height = resolve_border_block_size(node, sizing_input, mode, cursor_y - y);
                 node.rect.height = height;
                 return height;
             }
 
             // --- Block-level element: inline content + block children + padding ---
-
-            let bm = node.box_metrics();
 
             // Content box horizontally: inside padding-left/right
             let (content_x, content_width) = content_x_and_width_for_box(node, x, used_width);
@@ -200,8 +205,10 @@ fn recompute_block_heights<'style_tree, 'dom>(
 
             let children_height = cursor_y - content_start_y;
 
-            // 4) Total height = padding-top + inline + children + padding-bottom
-            let total_height = bm.padding_top + inline_height + children_height + bm.padding_bottom;
+            // 4) Resolve auto content height through the sizing contract.
+            let auto_content_height = inline_height + children_height;
+            let total_height =
+                resolve_border_block_size(node, sizing_input, mode, auto_content_height);
 
             node.rect.height = total_height;
             total_height
@@ -222,66 +229,56 @@ fn participates_in_parent_inline_flow(node: &LayoutBox<'_, '_>) -> bool {
     )
 }
 
-fn resolve_used_width_for_block(
-    style: &ComputedStyle,
-    node: &html::Node,
-    kind: BoxKind,
-    available_width: f32,
-) -> f32 {
-    // 1) Start from available width.
-    let mut w = available_width.max(0.0);
-
-    // 2) Apply explicit width for non-inline elements.
-    if let html::Node::Element { .. } = node {
-        if let (false, Some(Length::Px(px))) = (
-            matches!(style.display(), Display::Inline),
-            style
-                .width()
-                .filter(|len| matches!(len, Length::Px(px) if *px >= 0.0)),
-        ) {
-            w = px;
-        }
-
-        // Naïve shrink-to-fit **only** for inline-block:
-        //
-        // - If width was specified, we keep it but clamp to available_width.
-        // - If width was not specified, we just keep the "fill available" default.
-        // - In both cases we cap at available_width to avoid horizontal overflow.
-        if matches!(kind, BoxKind::InlineBlock) {
-            w = w.min(available_width.max(0.0));
-        }
+fn normal_flow_sizing_mode(node: &LayoutBox<'_, '_>) -> NormalFlowSizingMode {
+    if node.is_anonymous() {
+        return NormalFlowSizingMode::Anonymous;
     }
 
-    // 3) Apply min-width / max-width (px-only).
-    if let Some(Length::Px(min_px)) = style
-        .min_width()
-        .filter(|len| matches!(len, Length::Px(px) if *px >= 0.0))
-    {
-        w = w.max(min_px);
+    match node.block_formatting_participation() {
+        BlockFormattingParticipation::Root => NormalFlowSizingMode::Document,
+        BlockFormattingParticipation::BlockLevel => NormalFlowSizingMode::BlockLevel,
+        BlockFormattingParticipation::InlineLevel => NormalFlowSizingMode::InlineLevel,
+        BlockFormattingParticipation::AtomicInline => NormalFlowSizingMode::AtomicInline,
+        BlockFormattingParticipation::None => NormalFlowSizingMode::BlockLevel,
     }
-
-    if let Some(Length::Px(max_px)) = style
-        .max_width()
-        .filter(|len| matches!(len, Length::Px(px) if *px >= 0.0))
-    {
-        w = w.min(max_px);
-    }
-
-    // 4) FINAL clamp for inline-block (naïve shrink-to-fit)
-    if matches!(kind, BoxKind::InlineBlock) {
-        w = w.min(available_width.max(0.0));
-    }
-
-    // Final safety: never negative.
-    w.max(0.0)
 }
 
-fn resolve_used_width_for_layout_box(node: &LayoutBox<'_, '_>, available_width: f32) -> f32 {
-    if node.is_anonymous() {
-        return available_width.max(0.0);
+fn size_resolution_input_for_layout_box(
+    node: &LayoutBox<'_, '_>,
+    available_width: f32,
+) -> SizeResolutionInput {
+    let available_inline_size =
+        AvailableSize::Definite(CssPx::new(available_width.max(0.0)).expect("finite width"));
+    let constraint_space = ConstraintSpace::new(
+        node.containing_block(),
+        available_inline_size,
+        AvailableSize::Indefinite,
+    );
+    let style = if node.is_anonymous() {
+        StyleSizeInputs::auto_zero()
+    } else {
+        StyleSizeInputs::from_computed_style(node.style)
+            .expect("computed style must materialize deterministic sizing inputs")
+    };
+
+    SizeResolutionInput::new(constraint_space, style, IntrinsicSizes::zero())
+}
+
+fn resolve_border_block_size(
+    node: &LayoutBox<'_, '_>,
+    input: SizeResolutionInput,
+    mode: NormalFlowSizingMode,
+    auto_content_height: f32,
+) -> f32 {
+    if matches!(node.node.node, Node::Text { .. } | Node::Comment { .. }) {
+        return 0.0;
     }
 
-    resolve_used_width_for_block(node.style, node.node.node, node.kind, available_width)
+    let auto_content_height =
+        CssPx::new(auto_content_height.max(0.0)).expect("finite auto content height");
+    resolve_normal_flow_block_size(input, mode, auto_content_height)
+        .border()
+        .get()
 }
 
 fn content_x_and_width_for_box(

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -21,7 +21,9 @@
 //! structured sizing inputs are documented in
 //! `docs/rendering/x2-structured-size-resolution-model-inputs.md`; X3
 //! supported width/height resolution is documented in
-//! `docs/rendering/x3-width-height-resolution-supported-subset.md`.
+//! `docs/rendering/x3-width-height-resolution-supported-subset.md`; X4
+//! intrinsic sizing for supported content is documented in
+//! `docs/rendering/x4-intrinsic-sizing-supported-content.md`.
 //! `BoxTree` is the frame-local generated box-tree structure; `LayoutBox` is
 //! the current geometry projection consumed by paint and hit testing.
 

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -19,7 +19,9 @@
 //! sizing architecture and flow-correctness contracts are documented in
 //! `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`; X2
 //! structured sizing inputs are documented in
-//! `docs/rendering/x2-structured-size-resolution-model-inputs.md`.
+//! `docs/rendering/x2-structured-size-resolution-model-inputs.md`; X3
+//! supported width/height resolution is documented in
+//! `docs/rendering/x3-width-height-resolution-supported-subset.md`.
 //! `BoxTree` is the frame-local generated box-tree structure; `LayoutBox` is
 //! the current geometry projection consumed by paint and hit testing.
 
@@ -54,10 +56,12 @@ pub use phase::{LayoutPhaseInput, LayoutPhaseOutput};
 pub use replaced_element::{ReplacedElementInfoProvider, ReplacedKind};
 pub use sizing::{
     AppliedSizeConstraint, AspectRatio, AvailableSize, AvailableSpace, AxisSizeConstraints,
-    AxisStyleSizeInput, ConstraintSpace, ContainingSize, CssPx, IntrinsicSizes, Percentage,
-    PhysicalSides, SignedCssPx, SizeAxis, SizeConstraints, SizeResolutionInput,
-    SizeResolutionReason, StyleBoxMetrics, StyleMaximumSize, StyleMinimumSize, StylePreferredSize,
-    StyleSizeInputError, StyleSizeInputProperty, StyleSizeInputs, UsedAxisSize, UsedContentSize,
+    AxisStyleSizeInput, ConstraintSpace, ContainingSize, CssPx, IntrinsicSizes,
+    NormalFlowSizingMode, Percentage, PhysicalSides, ResolvedAxisSize, SignedCssPx, SizeAxis,
+    SizeConstraints, SizeResolutionInput, SizeResolutionReason, StyleBoxMetrics, StyleMaximumSize,
+    StyleMinimumSize, StylePreferredSize, StyleSizeInputError, StyleSizeInputProperty,
+    StyleSizeInputs, UsedAxisSize, UsedContentSize, resolve_normal_flow_block_size,
+    resolve_normal_flow_inline_size,
 };
 pub use text::TextMeasurer;
 

--- a/crates/layout/src/sizing.rs
+++ b/crates/layout/src/sizing.rs
@@ -334,6 +334,18 @@ pub struct StyleBoxMetrics {
 }
 
 impl StyleBoxMetrics {
+    pub fn zero() -> Self {
+        Self {
+            margin: PhysicalSides::new(
+                SignedCssPx::ZERO,
+                SignedCssPx::ZERO,
+                SignedCssPx::ZERO,
+                SignedCssPx::ZERO,
+            ),
+            padding: PhysicalSides::new(CssPx::ZERO, CssPx::ZERO, CssPx::ZERO, CssPx::ZERO),
+        }
+    }
+
     pub fn new(margin: PhysicalSides<SignedCssPx>, padding: PhysicalSides<CssPx>) -> Self {
         Self { margin, padding }
     }
@@ -434,6 +446,15 @@ pub struct StyleSizeInputs {
 }
 
 impl StyleSizeInputs {
+    pub fn auto_zero() -> Self {
+        let axis = AxisStyleSizeInput::new(
+            StylePreferredSize::Auto,
+            StyleMinimumSize::Auto,
+            StyleMaximumSize::None,
+        );
+        Self::new(axis, axis, StyleBoxMetrics::zero())
+    }
+
     pub fn new(
         inline: AxisStyleSizeInput,
         block: AxisStyleSizeInput,
@@ -581,6 +602,211 @@ impl SizeResolutionInput {
     }
 }
 
+/// Supported normal-flow sizing behavior for the current layout subset.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NormalFlowSizingMode {
+    Document,
+    BlockLevel,
+    InlineLevel,
+    AtomicInline,
+    Anonymous,
+}
+
+/// Resolved content-box and border-box size for one axis.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ResolvedAxisSize {
+    content: UsedAxisSize,
+    border: CssPx,
+}
+
+impl ResolvedAxisSize {
+    pub fn new(content: UsedAxisSize, border: CssPx) -> Self {
+        Self { content, border }
+    }
+
+    pub fn content(self) -> UsedAxisSize {
+        self.content
+    }
+
+    pub fn border(self) -> CssPx {
+        self.border
+    }
+}
+
+pub fn resolve_normal_flow_inline_size(
+    input: SizeResolutionInput,
+    mode: NormalFlowSizingMode,
+) -> ResolvedAxisSize {
+    let style = input.style();
+    let available_inline = input
+        .constraint_space()
+        .available_size(SizeAxis::Inline)
+        .definite_value();
+    let padding = style.box_metrics().padding();
+    let padding_inline = css_px_sum(padding.left(), padding.right());
+    let available_content =
+        available_inline.map(|available_inline| subtract_css_px(available_inline, padding_inline));
+    let basis = input
+        .constraint_space()
+        .containing_size_for_axis(SizeAxis::Inline);
+    let axis = style.inline();
+
+    let (preferred_value, preferred_reason) = match (mode, axis.preferred()) {
+        (NormalFlowSizingMode::InlineLevel, _) => auto_stretch_preferred(available_content),
+        (_, StylePreferredSize::Length(value)) => (value, SizeResolutionReason::DefiniteLength),
+        (_, StylePreferredSize::Percentage(percentage)) => percentage
+            .resolve_against(basis)
+            .map(|value| {
+                (
+                    value,
+                    SizeResolutionReason::PercentageOfDefiniteContainingBlock,
+                )
+            })
+            .unwrap_or((
+                CssPx::ZERO,
+                SizeResolutionReason::DeferredIndefinitePercentage,
+            )),
+        (_, StylePreferredSize::Auto) => auto_stretch_preferred(available_content),
+    };
+
+    let constraints = inline_constraints(axis, basis);
+    let (value, applied_constraint) =
+        apply_inline_size_adjustments(preferred_value, constraints, mode, available_content);
+    let used = used_axis_size(preferred_value, preferred_reason, value, applied_constraint);
+    let border = css_px_sum(value, padding_inline);
+
+    ResolvedAxisSize::new(used, border)
+}
+
+pub fn resolve_normal_flow_block_size(
+    input: SizeResolutionInput,
+    mode: NormalFlowSizingMode,
+    auto_content_block_size: CssPx,
+) -> ResolvedAxisSize {
+    let style = input.style();
+    let padding = style.box_metrics().padding();
+    let padding_block = css_px_sum(padding.top(), padding.bottom());
+    let basis = input
+        .constraint_space()
+        .containing_size_for_axis(SizeAxis::Block);
+    let axis = style.block();
+
+    let (preferred_value, preferred_reason) = match (mode, axis.preferred()) {
+        (NormalFlowSizingMode::InlineLevel, _) => {
+            (CssPx::ZERO, SizeResolutionReason::AutoContentBased)
+        }
+        (_, StylePreferredSize::Length(value)) => (value, SizeResolutionReason::DefiniteLength),
+        (_, StylePreferredSize::Percentage(percentage)) => percentage
+            .resolve_against(basis)
+            .map(|value| {
+                (
+                    value,
+                    SizeResolutionReason::PercentageOfDefiniteContainingBlock,
+                )
+            })
+            .unwrap_or((
+                CssPx::ZERO,
+                SizeResolutionReason::DeferredIndefinitePercentage,
+            )),
+        (_, StylePreferredSize::Auto) => (
+            auto_content_block_size,
+            SizeResolutionReason::AutoContentBased,
+        ),
+    };
+
+    let constraints = block_constraints(axis, basis);
+    let (value, applied_constraint) = constraints.clamp_with_applied_constraint(preferred_value);
+    let used = used_axis_size(preferred_value, preferred_reason, value, applied_constraint);
+    let border = css_px_sum(value, padding_block);
+
+    ResolvedAxisSize::new(used, border)
+}
+
+fn inline_constraints(axis: AxisStyleSizeInput, basis: AvailableSize) -> AxisSizeConstraints {
+    let min = match axis.min() {
+        StyleMinimumSize::Auto => None,
+        StyleMinimumSize::Length(value) => Some(value),
+        StyleMinimumSize::Percentage(percentage) => percentage.resolve_against(basis),
+    };
+
+    let style_max = match axis.max() {
+        StyleMaximumSize::None => None,
+        StyleMaximumSize::Length(value) => Some(value),
+        StyleMaximumSize::Percentage(percentage) => percentage.resolve_against(basis),
+    };
+
+    AxisSizeConstraints::new(min, style_max)
+}
+
+fn block_constraints(axis: AxisStyleSizeInput, basis: AvailableSize) -> AxisSizeConstraints {
+    let min = match axis.min() {
+        StyleMinimumSize::Auto => None,
+        StyleMinimumSize::Length(value) => Some(value),
+        StyleMinimumSize::Percentage(percentage) => percentage.resolve_against(basis),
+    };
+    let max = match axis.max() {
+        StyleMaximumSize::None => None,
+        StyleMaximumSize::Length(value) => Some(value),
+        StyleMaximumSize::Percentage(percentage) => percentage.resolve_against(basis),
+    };
+
+    AxisSizeConstraints::new(min, max)
+}
+
+fn used_axis_size(
+    preferred_value: CssPx,
+    preferred_reason: SizeResolutionReason,
+    value: CssPx,
+    applied_constraint: AppliedSizeConstraint,
+) -> UsedAxisSize {
+    match applied_constraint {
+        AppliedSizeConstraint::None => UsedAxisSize::unconstrained(value, preferred_reason),
+        AppliedSizeConstraint::Min
+        | AppliedSizeConstraint::Max
+        | AppliedSizeConstraint::AvailableSpaceClamp => {
+            UsedAxisSize::constrained(preferred_value, preferred_reason, value, applied_constraint)
+        }
+    }
+}
+
+fn auto_stretch_preferred(available_content: Option<CssPx>) -> (CssPx, SizeResolutionReason) {
+    available_content
+        .map(|available_content| {
+            (
+                available_content,
+                SizeResolutionReason::AutoStretchToContainingBlock,
+            )
+        })
+        .unwrap_or((CssPx::ZERO, SizeResolutionReason::UnsupportedDeferred))
+}
+
+fn apply_inline_size_adjustments(
+    preferred_value: CssPx,
+    constraints: AxisSizeConstraints,
+    mode: NormalFlowSizingMode,
+    available_content: Option<CssPx>,
+) -> (CssPx, AppliedSizeConstraint) {
+    let mut out = preferred_value;
+    let mut applied = AppliedSizeConstraint::None;
+
+    if let Some(max) = constraints.max().filter(|max| out > *max) {
+        out = max;
+        applied = AppliedSizeConstraint::Max;
+    }
+    if matches!(mode, NormalFlowSizingMode::AtomicInline) {
+        if let Some(available_content) = available_content.filter(|available| out > *available) {
+            out = available_content;
+            applied = AppliedSizeConstraint::AvailableSpaceClamp;
+        }
+    }
+    if let Some(min) = constraints.min().filter(|min| out < *min) {
+        out = min;
+        applied = AppliedSizeConstraint::Min;
+    }
+
+    (out, applied)
+}
+
 /// Min/max constraints for one logical axis.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AxisSizeConstraints {
@@ -674,12 +900,16 @@ pub enum SizeResolutionReason {
     UnsupportedDeferred,
 }
 
-/// Min/max constraint applied after preferred-size resolution.
+/// Post-preferred size adjustment applied after preferred-size resolution.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AppliedSizeConstraint {
     None,
+    /// A style `min-width`/`min-height` constraint produced the final size.
     Min,
+    /// A style `max-width`/`max-height` constraint produced the final size.
     Max,
+    /// The formatting context's definite available space clamped the final size.
+    AvailableSpaceClamp,
 }
 
 /// Used content-box size for one axis plus deterministic sizing metadata.
@@ -887,6 +1117,15 @@ fn signed_length(
     property: StyleSizeInputProperty,
 ) -> Result<SignedCssPx, StyleSizeInputError> {
     SignedCssPx::new(value).ok_or(StyleSizeInputError::InvalidFiniteLength { property, value })
+}
+
+fn css_px_sum(a: CssPx, b: CssPx) -> CssPx {
+    CssPx::new(a.get() + b.get()).expect("sum of finite non-negative CSS px values is valid")
+}
+
+fn subtract_css_px(value: CssPx, amount: CssPx) -> CssPx {
+    CssPx::new((value.get() - amount.get()).max(0.0))
+        .expect("clamped difference of CSS px values is valid")
 }
 
 #[cfg(test)]
@@ -1210,5 +1449,271 @@ mod tests {
         assert_eq!(input.constraint_space(), constraint_space);
         assert_eq!(input.style(), style);
         assert_eq!(input.intrinsic(), intrinsic);
+    }
+
+    #[test]
+    fn normal_flow_auto_inline_size_fills_available_border_box_after_padding() {
+        let input = size_input_with_style(
+            ComputedStyle::initial()
+                .with_property(
+                    PropertyId::PaddingLeft,
+                    ComputedValue::Length(Length::Px(10.0)),
+                )
+                .expect("padding-left")
+                .with_property(
+                    PropertyId::PaddingRight,
+                    ComputedValue::Length(Length::Px(15.0)),
+                )
+                .expect("padding-right"),
+            200.0,
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::BlockLevel);
+
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(175.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().preferred_reason(),
+            SizeResolutionReason::AutoStretchToContainingBlock
+        );
+        assert_eq!(resolved.border(), CssPx::new(200.0).expect("border"));
+    }
+
+    #[test]
+    fn normal_flow_explicit_width_is_content_box_and_padding_expands_border_box() {
+        let input = size_input_with_style(
+            ComputedStyle::initial()
+                .with_property(
+                    PropertyId::Width,
+                    ComputedValue::LengthOrAuto(Some(Length::Px(100.0))),
+                )
+                .expect("width")
+                .with_property(
+                    PropertyId::PaddingLeft,
+                    ComputedValue::Length(Length::Px(10.0)),
+                )
+                .expect("padding-left")
+                .with_property(
+                    PropertyId::PaddingRight,
+                    ComputedValue::Length(Length::Px(15.0)),
+                )
+                .expect("padding-right"),
+            500.0,
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::BlockLevel);
+
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(100.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().preferred_reason(),
+            SizeResolutionReason::DefiniteLength
+        );
+        assert_eq!(resolved.border(), CssPx::new(125.0).expect("border"));
+    }
+
+    #[test]
+    fn normal_flow_min_max_constraints_apply_to_content_box_before_padding() {
+        let input = size_input_with_style(
+            ComputedStyle::initial()
+                .with_property(
+                    PropertyId::Width,
+                    ComputedValue::LengthOrAuto(Some(Length::Px(200.0))),
+                )
+                .expect("width")
+                .with_property(
+                    PropertyId::MaxWidth,
+                    ComputedValue::LengthOrNone(Some(Length::Px(120.0))),
+                )
+                .expect("max-width")
+                .with_property(
+                    PropertyId::PaddingLeft,
+                    ComputedValue::Length(Length::Px(10.0)),
+                )
+                .expect("padding-left")
+                .with_property(
+                    PropertyId::PaddingRight,
+                    ComputedValue::Length(Length::Px(10.0)),
+                )
+                .expect("padding-right"),
+            500.0,
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::BlockLevel);
+
+        assert_eq!(
+            resolved.content().preferred_value(),
+            CssPx::new(200.0).expect("preferred")
+        );
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(120.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().applied_constraint(),
+            AppliedSizeConstraint::Max
+        );
+        assert_eq!(resolved.border(), CssPx::new(140.0).expect("border"));
+    }
+
+    #[test]
+    fn normal_flow_min_width_applies_to_content_box_before_padding() {
+        let input = size_input_with_style(
+            ComputedStyle::initial()
+                .with_property(
+                    PropertyId::Width,
+                    ComputedValue::LengthOrAuto(Some(Length::Px(80.0))),
+                )
+                .expect("width")
+                .with_property(
+                    PropertyId::MinWidth,
+                    ComputedValue::LengthOrAuto(Some(Length::Px(120.0))),
+                )
+                .expect("min-width")
+                .with_property(
+                    PropertyId::PaddingLeft,
+                    ComputedValue::Length(Length::Px(10.0)),
+                )
+                .expect("padding-left")
+                .with_property(
+                    PropertyId::PaddingRight,
+                    ComputedValue::Length(Length::Px(10.0)),
+                )
+                .expect("padding-right"),
+            500.0,
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::BlockLevel);
+
+        assert_eq!(
+            resolved.content().preferred_value(),
+            CssPx::new(80.0).expect("preferred")
+        );
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(120.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().applied_constraint(),
+            AppliedSizeConstraint::Min
+        );
+        assert_eq!(resolved.border(), CssPx::new(140.0).expect("border"));
+    }
+
+    #[test]
+    fn atomic_inline_available_space_clamp_is_not_reported_as_style_max() {
+        let input = size_input_with_style(
+            ComputedStyle::initial()
+                .with_property(
+                    PropertyId::Width,
+                    ComputedValue::LengthOrAuto(Some(Length::Px(200.0))),
+                )
+                .expect("width"),
+            100.0,
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::AtomicInline);
+
+        assert_eq!(
+            resolved.content().preferred_value(),
+            CssPx::new(200.0).expect("preferred")
+        );
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(100.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().applied_constraint(),
+            AppliedSizeConstraint::AvailableSpaceClamp
+        );
+        assert_eq!(resolved.border(), CssPx::new(100.0).expect("border"));
+    }
+
+    #[test]
+    fn atomic_inline_width_is_not_clamped_when_available_inline_size_is_indefinite() {
+        let input = size_input_with_available_inline_size(
+            ComputedStyle::initial()
+                .with_property(
+                    PropertyId::Width,
+                    ComputedValue::LengthOrAuto(Some(Length::Px(100.0))),
+                )
+                .expect("width"),
+            AvailableSize::Indefinite,
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::AtomicInline);
+
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(100.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().applied_constraint(),
+            AppliedSizeConstraint::None
+        );
+        assert_eq!(resolved.border(), CssPx::new(100.0).expect("border"));
+    }
+
+    #[test]
+    fn normal_flow_explicit_height_is_content_box_and_padding_expands_border_box() {
+        let input = size_input_with_style(
+            ComputedStyle::initial()
+                .with_property(
+                    PropertyId::Height,
+                    ComputedValue::LengthOrAuto(Some(Length::Px(40.0))),
+                )
+                .expect("height")
+                .with_property(
+                    PropertyId::PaddingTop,
+                    ComputedValue::Length(Length::Px(5.0)),
+                )
+                .expect("padding-top")
+                .with_property(
+                    PropertyId::PaddingBottom,
+                    ComputedValue::Length(Length::Px(7.0)),
+                )
+                .expect("padding-bottom"),
+            500.0,
+        );
+
+        let resolved = resolve_normal_flow_block_size(
+            input,
+            NormalFlowSizingMode::BlockLevel,
+            CssPx::new(120.0).expect("auto content"),
+        );
+
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(40.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().preferred_reason(),
+            SizeResolutionReason::DefiniteLength
+        );
+        assert_eq!(resolved.border(), CssPx::new(52.0).expect("border"));
+    }
+
+    fn size_input_with_style(
+        style: ComputedStyle,
+        available_inline_size: f32,
+    ) -> SizeResolutionInput {
+        size_input_with_available_inline_size(
+            style,
+            AvailableSize::definite(available_inline_size).expect("available inline size"),
+        )
+    }
+
+    fn size_input_with_available_inline_size(
+        style: ComputedStyle,
+        available_inline_size: AvailableSize,
+    ) -> SizeResolutionInput {
+        let constraint_space =
+            ConstraintSpace::new(None, available_inline_size, AvailableSize::Indefinite);
+        let style = StyleSizeInputs::from_computed_style(&style).expect("style inputs");
+        SizeResolutionInput::new(constraint_space, style, IntrinsicSizes::zero())
     }
 }

--- a/crates/layout/src/sizing.rs
+++ b/crates/layout/src/sizing.rs
@@ -650,6 +650,7 @@ pub fn resolve_normal_flow_inline_size(
         .constraint_space()
         .containing_size_for_axis(SizeAxis::Inline);
     let axis = style.inline();
+    let intrinsic = input.intrinsic();
 
     let (preferred_value, preferred_reason) = match (mode, axis.preferred()) {
         (NormalFlowSizingMode::InlineLevel, _) => auto_stretch_preferred(available_content),
@@ -666,12 +667,24 @@ pub fn resolve_normal_flow_inline_size(
                 CssPx::ZERO,
                 SizeResolutionReason::DeferredIndefinitePercentage,
             )),
+        (NormalFlowSizingMode::AtomicInline, StylePreferredSize::Auto) => {
+            atomic_inline_auto_preferred(intrinsic, available_content)
+        }
         (_, StylePreferredSize::Auto) => auto_stretch_preferred(available_content),
     };
 
     let constraints = inline_constraints(axis, basis);
-    let (value, applied_constraint) =
-        apply_inline_size_adjustments(preferred_value, constraints, mode, available_content);
+    let allow_available_space_clamp = !matches!(
+        (mode, axis.preferred()),
+        (NormalFlowSizingMode::AtomicInline, StylePreferredSize::Auto)
+    );
+    let (value, applied_constraint) = apply_inline_size_adjustments(
+        preferred_value,
+        constraints,
+        mode,
+        available_content,
+        allow_available_space_clamp,
+    );
     let used = used_axis_size(preferred_value, preferred_reason, value, applied_constraint);
     let border = css_px_sum(value, padding_inline);
 
@@ -780,11 +793,50 @@ fn auto_stretch_preferred(available_content: Option<CssPx>) -> (CssPx, SizeResol
         .unwrap_or((CssPx::ZERO, SizeResolutionReason::UnsupportedDeferred))
 }
 
+fn atomic_inline_auto_preferred(
+    intrinsic: IntrinsicSizes,
+    available_content: Option<CssPx>,
+) -> (CssPx, SizeResolutionReason) {
+    let max_content = intrinsic
+        .preferred_inline_size()
+        .unwrap_or(intrinsic.max_content_inline_size());
+    if max_content == CssPx::ZERO {
+        return (CssPx::ZERO, SizeResolutionReason::AutoContentBased);
+    }
+
+    match available_content {
+        Some(available_content) => (
+            shrink_to_fit_inline_size(
+                intrinsic.min_content_inline_size(),
+                max_content,
+                available_content,
+            ),
+            SizeResolutionReason::ShrinkToFit,
+        ),
+        None => (max_content, SizeResolutionReason::IntrinsicPreferredSize),
+    }
+}
+
+fn shrink_to_fit_inline_size(
+    min_content: CssPx,
+    max_content: CssPx,
+    available_content: CssPx,
+) -> CssPx {
+    if available_content < min_content {
+        min_content
+    } else if available_content > max_content {
+        max_content
+    } else {
+        available_content
+    }
+}
+
 fn apply_inline_size_adjustments(
     preferred_value: CssPx,
     constraints: AxisSizeConstraints,
     mode: NormalFlowSizingMode,
     available_content: Option<CssPx>,
+    allow_available_space_clamp: bool,
 ) -> (CssPx, AppliedSizeConstraint) {
     let mut out = preferred_value;
     let mut applied = AppliedSizeConstraint::None;
@@ -793,7 +845,7 @@ fn apply_inline_size_adjustments(
         out = max;
         applied = AppliedSizeConstraint::Max;
     }
-    if matches!(mode, NormalFlowSizingMode::AtomicInline) {
+    if allow_available_space_clamp && matches!(mode, NormalFlowSizingMode::AtomicInline) {
         if let Some(available_content) = available_content.filter(|available| out > *available) {
             out = available_content;
             applied = AppliedSizeConstraint::AvailableSpaceClamp;
@@ -1659,6 +1711,134 @@ mod tests {
     }
 
     #[test]
+    fn atomic_inline_auto_width_uses_intrinsic_max_content_when_available_is_larger() {
+        let input = size_input_with_intrinsic(
+            ComputedStyle::initial(),
+            500.0,
+            IntrinsicSizes::new(
+                CssPx::new(40.0).expect("min-content"),
+                CssPx::new(120.0).expect("max-content"),
+                Some(CssPx::new(120.0).expect("preferred")),
+                None,
+                None,
+            )
+            .expect("intrinsic"),
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::AtomicInline);
+
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(120.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().preferred_reason(),
+            SizeResolutionReason::ShrinkToFit
+        );
+        assert_eq!(
+            resolved.content().applied_constraint(),
+            AppliedSizeConstraint::None
+        );
+        assert_eq!(resolved.border(), CssPx::new(120.0).expect("border"));
+    }
+
+    #[test]
+    fn atomic_inline_auto_width_shrink_to_fit_uses_available_between_min_and_max_content() {
+        let input = size_input_with_intrinsic(
+            ComputedStyle::initial(),
+            80.0,
+            IntrinsicSizes::new(
+                CssPx::new(40.0).expect("min-content"),
+                CssPx::new(120.0).expect("max-content"),
+                Some(CssPx::new(120.0).expect("preferred")),
+                None,
+                None,
+            )
+            .expect("intrinsic"),
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::AtomicInline);
+
+        assert_eq!(
+            resolved.content().preferred_value(),
+            CssPx::new(80.0).expect("preferred")
+        );
+        assert_eq!(
+            resolved.content().preferred_reason(),
+            SizeResolutionReason::ShrinkToFit
+        );
+        assert_eq!(
+            resolved.content().applied_constraint(),
+            AppliedSizeConstraint::None
+        );
+        assert_eq!(resolved.border(), CssPx::new(80.0).expect("border"));
+    }
+
+    #[test]
+    fn atomic_inline_auto_width_uses_intrinsic_preferred_when_available_is_indefinite() {
+        let input = size_input_with_available_inline_and_intrinsic(
+            ComputedStyle::initial(),
+            AvailableSize::Indefinite,
+            IntrinsicSizes::new(
+                CssPx::new(40.0).expect("min-content"),
+                CssPx::new(120.0).expect("max-content"),
+                Some(CssPx::new(120.0).expect("preferred")),
+                None,
+                None,
+            )
+            .expect("intrinsic"),
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::AtomicInline);
+
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(120.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().preferred_reason(),
+            SizeResolutionReason::IntrinsicPreferredSize
+        );
+        assert_eq!(
+            resolved.content().applied_constraint(),
+            AppliedSizeConstraint::None
+        );
+        assert_eq!(resolved.border(), CssPx::new(120.0).expect("border"));
+    }
+
+    #[test]
+    fn atomic_inline_explicit_width_still_overrides_intrinsic_width() {
+        let input = size_input_with_intrinsic(
+            ComputedStyle::initial()
+                .with_property(
+                    PropertyId::Width,
+                    ComputedValue::LengthOrAuto(Some(Length::Px(90.0))),
+                )
+                .expect("width"),
+            500.0,
+            IntrinsicSizes::new(
+                CssPx::new(40.0).expect("min-content"),
+                CssPx::new(120.0).expect("max-content"),
+                Some(CssPx::new(120.0).expect("preferred")),
+                None,
+                None,
+            )
+            .expect("intrinsic"),
+        );
+
+        let resolved = resolve_normal_flow_inline_size(input, NormalFlowSizingMode::AtomicInline);
+
+        assert_eq!(
+            resolved.content().value(),
+            CssPx::new(90.0).expect("content")
+        );
+        assert_eq!(
+            resolved.content().preferred_reason(),
+            SizeResolutionReason::DefiniteLength
+        );
+    }
+
+    #[test]
     fn normal_flow_explicit_height_is_content_box_and_padding_expands_border_box() {
         let input = size_input_with_style(
             ComputedStyle::initial()
@@ -1701,9 +1881,18 @@ mod tests {
         style: ComputedStyle,
         available_inline_size: f32,
     ) -> SizeResolutionInput {
-        size_input_with_available_inline_size(
+        size_input_with_intrinsic(style, available_inline_size, IntrinsicSizes::zero())
+    }
+
+    fn size_input_with_intrinsic(
+        style: ComputedStyle,
+        available_inline_size: f32,
+        intrinsic: IntrinsicSizes,
+    ) -> SizeResolutionInput {
+        size_input_with_available_inline_and_intrinsic(
             style,
             AvailableSize::definite(available_inline_size).expect("available inline size"),
+            intrinsic,
         )
     }
 
@@ -1711,9 +1900,21 @@ mod tests {
         style: ComputedStyle,
         available_inline_size: AvailableSize,
     ) -> SizeResolutionInput {
+        size_input_with_available_inline_and_intrinsic(
+            style,
+            available_inline_size,
+            IntrinsicSizes::zero(),
+        )
+    }
+
+    fn size_input_with_available_inline_and_intrinsic(
+        style: ComputedStyle,
+        available_inline_size: AvailableSize,
+        intrinsic: IntrinsicSizes,
+    ) -> SizeResolutionInput {
         let constraint_space =
             ConstraintSpace::new(None, available_inline_size, AvailableSize::Indefinite);
         let style = StyleSizeInputs::from_computed_style(&style).expect("style inputs");
-        SizeResolutionInput::new(constraint_space, style, IntrinsicSizes::zero())
+        SizeResolutionInput::new(constraint_space, style, intrinsic)
     }
 }

--- a/crates/layout/src/sizing.rs
+++ b/crates/layout/src/sizing.rs
@@ -845,11 +845,12 @@ fn apply_inline_size_adjustments(
         out = max;
         applied = AppliedSizeConstraint::Max;
     }
-    if allow_available_space_clamp && matches!(mode, NormalFlowSizingMode::AtomicInline) {
-        if let Some(available_content) = available_content.filter(|available| out > *available) {
-            out = available_content;
-            applied = AppliedSizeConstraint::AvailableSpaceClamp;
-        }
+    if allow_available_space_clamp
+        && matches!(mode, NormalFlowSizingMode::AtomicInline)
+        && let Some(available_content) = available_content.filter(|available| out > *available)
+    {
+        out = available_content;
+        applied = AppliedSizeConstraint::AvailableSpaceClamp;
     }
     if let Some(min) = constraints.min().filter(|min| out < *min) {
         out = min;

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -318,6 +318,7 @@ The normative rendering ownership and phase-boundary contract lives in:
 * `docs/rendering/w9-box-tree-invariants-extension-hooks.md`
 * `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
 * `docs/rendering/x2-structured-size-resolution-model-inputs.md`
+* `docs/rendering/x3-width-height-resolution-supported-subset.md`
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -319,6 +319,7 @@ The normative rendering ownership and phase-boundary contract lives in:
 * `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
 * `docs/rendering/x2-structured-size-resolution-model-inputs.md`
 * `docs/rendering/x3-width-height-resolution-supported-subset.md`
+* `docs/rendering/x4-intrinsic-sizing-supported-content.md`
 
 ---
 

--- a/docs/rendering/v7-rendering-pipeline-invariants-and-extension-hooks.md
+++ b/docs/rendering/v7-rendering-pipeline-invariants-and-extension-hooks.md
@@ -35,6 +35,7 @@ Related documents:
 - `docs/rendering/w9-box-tree-invariants-extension-hooks.md`
 - `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
 - `docs/rendering/x2-structured-size-resolution-model-inputs.md`
+- `docs/rendering/x3-width-height-resolution-supported-subset.md`
 - `docs/architecture/ARCHITECTURE.md`
 - `docs/css/u8-runtime-integration-contracts-extension-points.md`
 

--- a/docs/rendering/v7-rendering-pipeline-invariants-and-extension-hooks.md
+++ b/docs/rendering/v7-rendering-pipeline-invariants-and-extension-hooks.md
@@ -36,6 +36,7 @@ Related documents:
 - `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
 - `docs/rendering/x2-structured-size-resolution-model-inputs.md`
 - `docs/rendering/x3-width-height-resolution-supported-subset.md`
+- `docs/rendering/x4-intrinsic-sizing-supported-content.md`
 - `docs/architecture/ARCHITECTURE.md`
 - `docs/css/u8-runtime-integration-contracts-extension-points.md`
 

--- a/docs/rendering/w9-box-tree-invariants-extension-hooks.md
+++ b/docs/rendering/w9-box-tree-invariants-extension-hooks.md
@@ -25,6 +25,7 @@ Related documents:
 - `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
 - `docs/rendering/x2-structured-size-resolution-model-inputs.md`
 - `docs/rendering/x3-width-height-resolution-supported-subset.md`
+- `docs/rendering/x4-intrinsic-sizing-supported-content.md`
 - `docs/rendering/v1-rendering-architecture-ownership-phase-contracts.md`
 - `docs/rendering/v2-rendering-pipeline-phase-output-models.md`
 - `docs/rendering/v6-deterministic-debug-surfaces-and-phase-regression-coverage.md`

--- a/docs/rendering/w9-box-tree-invariants-extension-hooks.md
+++ b/docs/rendering/w9-box-tree-invariants-extension-hooks.md
@@ -24,6 +24,7 @@ Related documents:
 - `docs/rendering/w8-box-generation-formatting-debug-surfaces.md`
 - `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
 - `docs/rendering/x2-structured-size-resolution-model-inputs.md`
+- `docs/rendering/x3-width-height-resolution-supported-subset.md`
 - `docs/rendering/v1-rendering-architecture-ownership-phase-contracts.md`
 - `docs/rendering/v2-rendering-pipeline-phase-output-models.md`
 - `docs/rendering/v6-deterministic-debug-surfaces-and-phase-regression-coverage.md`

--- a/docs/rendering/x1-sizing-architecture-flow-correctness-contract.md
+++ b/docs/rendering/x1-sizing-architecture-flow-correctness-contract.md
@@ -25,6 +25,7 @@ Related code:
 Related documents:
 - `docs/rendering/x2-structured-size-resolution-model-inputs.md`
 - `docs/rendering/x3-width-height-resolution-supported-subset.md`
+- `docs/rendering/x4-intrinsic-sizing-supported-content.md`
 - `docs/rendering/w1-box-tree-layout-model-contract.md`
 - `docs/rendering/w5-containing-block-relationships.md`
 - `docs/rendering/w6-block-formatting-context-foundations.md`

--- a/docs/rendering/x1-sizing-architecture-flow-correctness-contract.md
+++ b/docs/rendering/x1-sizing-architecture-flow-correctness-contract.md
@@ -24,6 +24,7 @@ Related code:
 
 Related documents:
 - `docs/rendering/x2-structured-size-resolution-model-inputs.md`
+- `docs/rendering/x3-width-height-resolution-supported-subset.md`
 - `docs/rendering/w1-box-tree-layout-model-contract.md`
 - `docs/rendering/w5-containing-block-relationships.md`
 - `docs/rendering/w6-block-formatting-context-foundations.md`
@@ -152,12 +153,13 @@ the sizing subsystem for used sizes and intrinsic contributions.
   contributions.
 - `AxisSizeConstraints` and `SizeConstraints`: min/max constraints with the
   invariant that min wins if min and max cross.
-- `AppliedSizeConstraint`: records whether min, max, or neither changed the
-  preferred size.
+- `AppliedSizeConstraint`: records whether min, max, available-space clamping,
+  or no post-preferred adjustment produced the final size.
 - `UsedAxisSize`: resolved content-box size for one axis, preserving both the
-  preferred value/reason and the final value after constraints.
+  preferred value/reason and the final value after post-preferred adjustments.
 - `UsedContentSize`: resolved logical content-box size for both axes.
-- `SizeResolutionReason`: deterministic explanation for a used-size result.
+- `SizeResolutionReason`: deterministic explanation for preferred-size
+  selection before post-preferred adjustments.
 
 Later implementation may add resolver functions, debug labels, and richer value
 types, but it must preserve this separation between inputs, intrinsic
@@ -297,8 +299,8 @@ In scope:
 - min overriding max when constraints cross
 - recomputing aspect-ratio-derived counterpart sizes when a constrained inline
   size changes and the opposite axis is auto
-- debug visibility into whether a size came from the preferred result or a
-  constraint
+- debug visibility into whether a size came from the preferred result, a
+  constraint, or an available-space clamp
 
 Deferred:
 
@@ -311,8 +313,9 @@ Deferred:
 Constraint application belongs after preferred size selection for the axis. It
 must not be duplicated in replaced-element, inline, or block layout helpers.
 Constraint metadata must preserve the preferred value and preferred
-`SizeResolutionReason`; min/max application is an operation after preferred-size
-resolution, not a replacement for the original sizing reason.
+`SizeResolutionReason`; min/max and available-space adjustments are operations
+after preferred-size resolution, not replacements for the original sizing
+reason.
 
 ## Shrink-To-Fit Scope
 
@@ -377,10 +380,10 @@ Debug surfaces must expose enough information to identify sizing regressions:
 - input available sizes and whether they are definite or indefinite
 - containing-block identity used as percentage basis
 - intrinsic contributions for supported content types
-- preferred size before constraints where meaningful
+- preferred size before post-preferred adjustments where meaningful
 - preferred `SizeResolutionReason`
-- applied min/max constraints
-- final used content size after constraints
+- applied min/max constraints or available-space clamps
+- final used content size after post-preferred adjustments
 
 The existing `LayoutPhaseInput::to_debug_snapshot`,
 `BoxTree::to_debug_snapshot`, and `LayoutPhaseOutput::to_debug_snapshot`

--- a/docs/rendering/x2-structured-size-resolution-model-inputs.md
+++ b/docs/rendering/x2-structured-size-resolution-model-inputs.md
@@ -16,6 +16,7 @@ Related code:
 Related documents:
 - `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
 - `docs/rendering/x3-width-height-resolution-supported-subset.md`
+- `docs/rendering/x4-intrinsic-sizing-supported-content.md`
 - `docs/rendering/w5-containing-block-relationships.md`
 - `docs/rendering/w6-block-formatting-context-foundations.md`
 - `docs/rendering/w7-inline-formatting-context-foundations.md`

--- a/docs/rendering/x2-structured-size-resolution-model-inputs.md
+++ b/docs/rendering/x2-structured-size-resolution-model-inputs.md
@@ -15,6 +15,7 @@ Related code:
 
 Related documents:
 - `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
+- `docs/rendering/x3-width-height-resolution-supported-subset.md`
 - `docs/rendering/w5-containing-block-relationships.md`
 - `docs/rendering/w6-block-formatting-context-foundations.md`
 - `docs/rendering/w7-inline-formatting-context-foundations.md`

--- a/docs/rendering/x3-width-height-resolution-supported-subset.md
+++ b/docs/rendering/x3-width-height-resolution-supported-subset.md
@@ -1,0 +1,154 @@
+# X3: Width And Height Resolution For The Supported Subset
+
+Last updated: 2026-05-06  
+Status: implemented width and height resolution for Milestone X issue 3
+
+This document defines the first concrete used-size resolver built on the X1/X2
+sizing contracts. X3 strengthens Borrowser's supported normal-flow width and
+height behavior without introducing flex, positioning, border sizing,
+percentages in CSS parsing, or full shrink-to-fit algorithms.
+
+Related code:
+- `crates/layout/src/sizing.rs`
+- `crates/layout/src/inline/refine.rs`
+- `crates/layout/src/layout_box.rs`
+- `crates/layout/src/geometry.rs`
+- `crates/layout/src/box_tree/tests/projection.rs`
+
+Related documents:
+- `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
+- `docs/rendering/x2-structured-size-resolution-model-inputs.md`
+- `docs/rendering/w5-containing-block-relationships.md`
+- `docs/rendering/w6-block-formatting-context-foundations.md`
+- `docs/rendering/w7-inline-formatting-context-foundations.md`
+- `docs/rendering/w9-box-tree-invariants-extension-hooks.md`
+
+## Purpose
+
+Before X3, normal-flow layout mixed sizing decisions directly into recursive
+geometry refinement. Width was mostly passed through as an available border-box
+number, explicit `width` behaved like border-box width, and explicit `height`
+was not applied to ordinary normal-flow boxes.
+
+X3 introduces resolver functions that consume `SizeResolutionInput` and produce
+deterministic content-box used sizes plus border-box geometry sizes. The
+inline-aware normal-flow refinement pass now uses those functions as the
+authoritative source for box `rect.width` and `rect.height`.
+
+## Supported Resolution Model
+
+The supported model is still intentionally narrow:
+
+- horizontal writing-mode only
+- no borders
+- no `box-sizing`
+- no `min-height` or `max-height` CSS properties yet
+- no parsed CSS percentages yet
+- normal-flow block, anonymous block, document/root, inline-level, and atomic
+  inline sizing roles
+
+Within that subset, the contract is:
+
+- `width` and `height` are content-box sizes.
+- Padding expands the final border-box geometry.
+- Auto block-level width stretches to the available inline space offered by the
+  containing formatting context, with content size reduced by own padding.
+- Explicit width/height are preferred content sizes.
+- `min-width` and `max-width` apply to content width before padding expands the
+  border box.
+- Auto height is content-derived from inline lines and block children.
+- Explicit height overrides content-derived auto height and is then expanded by
+  vertical padding.
+- Atomic inline boxes keep the current supported shrink-to-fit-equivalent
+  behavior by clamping content width to definite available inline content
+  space.
+- Indefinite available inline size does not synthesize a zero available-space
+  clamp. Unsupported auto-stretch cases are deferred explicitly.
+- Anonymous generated boxes use zero box metrics for sizing, even though they
+  retain an anchor style for bridge compatibility.
+
+## Resolver Entry Points
+
+`crates/layout/src/sizing.rs` provides:
+
+- `NormalFlowSizingMode`
+- `ResolvedAxisSize`
+- `resolve_normal_flow_inline_size`
+- `resolve_normal_flow_block_size`
+
+`ResolvedAxisSize` exposes:
+
+- `content`: the `UsedAxisSize` content-box result, including preferred reason
+  and applied post-preferred adjustment metadata
+- `border`: the border-box axis size used by `LayoutBox::rect`
+
+This preserves the X1 distinction between preferred-size selection,
+post-preferred min/max or available-space adjustment, and final geometry
+conversion.
+
+## Integration With Normal Flow
+
+`inline::refine_layout_with_inline` remains the authoritative normal-flow
+geometry pass. It now:
+
+- builds a `SizeResolutionInput` for each `LayoutBox`
+- resolves inline size before laying out descendants
+- computes child and line content heights
+- resolves block size after content height is known
+- writes the resolved border-box sizes to `LayoutBox::rect`
+
+The initial `LayoutBox` projection still creates placeholder geometry. Final
+used width and height are owned by the refinement pass.
+
+## Determinism And Tests
+
+X3 adds resolver-level tests for:
+
+- auto width filling the available border box after padding
+- explicit width as content-box size
+- min/max constraints applying to content width before padding
+- atomic inline available-space clamping being distinct from style `max-width`
+- indefinite available inline size not clamping atomic inline width to zero
+- explicit height as content-box size
+
+X3 also adds layout-level regression tests for:
+
+- explicit width plus padding
+- auto width plus padding
+- max-width plus padding
+- min-width plus padding
+- explicit height plus padding
+- nested auto width derived from the parent content box
+- atomic inline width clamping to available content space
+- anonymous generated boxes not inheriting anchor padding for sizing
+
+These tests exercise both the pure sizing model and the integrated normal-flow
+geometry path.
+
+## Deferred Work
+
+X3 intentionally does not implement:
+
+- CSS percentage parsing
+- percentage width/height behavior in live layout
+- min-height or max-height
+- borders or `box-sizing`
+- margin auto distribution
+- full CSS 2.1 block width equation support
+- intrinsic shrink-to-fit for inline-blocks
+- replaced-element sizing migration into the shared resolver
+- floats, positioning, flex, grid, table, or fragmentation sizing
+
+Those features must extend the X1/X2 sizing contracts deliberately.
+
+## Exit Contract
+
+X3 is complete while these remain true:
+
+- supported normal-flow width resolution uses the structured sizing model
+- supported normal-flow height resolution uses the structured sizing model
+- CSS width/height behave as content-box sizes in the supported subset
+- min/max-width constraints apply before padding expansion
+- normal-flow layout derives descendant available width from parent content
+  width
+- representative resolver and layout regression tests pass

--- a/docs/rendering/x3-width-height-resolution-supported-subset.md
+++ b/docs/rendering/x3-width-height-resolution-supported-subset.md
@@ -10,6 +10,7 @@ percentages in CSS parsing, or full shrink-to-fit algorithms.
 
 Related code:
 - `crates/layout/src/sizing.rs`
+- `crates/layout/src/inline/intrinsic.rs`
 - `crates/layout/src/inline/refine.rs`
 - `crates/layout/src/layout_box.rs`
 - `crates/layout/src/geometry.rs`
@@ -18,6 +19,7 @@ Related code:
 Related documents:
 - `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
 - `docs/rendering/x2-structured-size-resolution-model-inputs.md`
+- `docs/rendering/x4-intrinsic-sizing-supported-content.md`
 - `docs/rendering/w5-containing-block-relationships.md`
 - `docs/rendering/w6-block-formatting-context-foundations.md`
 - `docs/rendering/w7-inline-formatting-context-foundations.md`
@@ -135,7 +137,7 @@ X3 intentionally does not implement:
 - borders or `box-sizing`
 - margin auto distribution
 - full CSS 2.1 block width equation support
-- intrinsic shrink-to-fit for inline-blocks
+- broader intrinsic shrink-to-fit beyond the X4 supported atomic-inline subset
 - replaced-element sizing migration into the shared resolver
 - floats, positioning, flex, grid, table, or fragmentation sizing
 

--- a/docs/rendering/x4-intrinsic-sizing-supported-content.md
+++ b/docs/rendering/x4-intrinsic-sizing-supported-content.md
@@ -1,0 +1,133 @@
+# X4: Intrinsic Sizing For Supported Content
+
+Last updated: 2026-05-06  
+Status: implemented intrinsic sizing for Milestone X issue 4
+
+This document defines the first concrete intrinsic sizing behavior built on the
+X1-X3 sizing contracts. X4 gives Borrowser deterministic intrinsic inline-size
+contributions for the supported normal-flow subset and wires those
+contributions into auto atomic inline sizing.
+
+Related code:
+- `crates/layout/src/sizing.rs`
+- `crates/layout/src/inline/intrinsic.rs`
+- `crates/layout/src/inline/refine.rs`
+- `crates/layout/src/box_tree/tests/projection.rs`
+
+Related documents:
+- `docs/rendering/x1-sizing-architecture-flow-correctness-contract.md`
+- `docs/rendering/x2-structured-size-resolution-model-inputs.md`
+- `docs/rendering/x3-width-height-resolution-supported-subset.md`
+- `docs/rendering/w7-inline-formatting-context-foundations.md`
+- `docs/rendering/w9-box-tree-invariants-extension-hooks.md`
+
+## Purpose
+
+Before X4, the layout pass always supplied `IntrinsicSizes::zero()` to
+`SizeResolutionInput`. That made X1/X2 structurally correct, but auto-sized
+atomic inline boxes still behaved as if content did not exist.
+
+X4 introduces a deterministic intrinsic contribution pass for supported content
+types and uses those contributions during used inline-size resolution.
+
+## Supported Intrinsic Contributions
+
+The current intrinsic pass supports:
+
+- text runs in the current HTML-like whitespace-collapsing subset
+- inline containers that flatten text and nested inline containers into one
+  inline contribution stream
+- atomic inline boxes, including inline-block boxes and replaced inline boxes
+- block containers by taking the maximum of direct block-flow child
+  contributions and own inline-formatting-context contributions
+- replaced inline metadata currently available to layout, including images,
+  text inputs, textareas, checkbox/radio controls, and buttons
+
+Text min-content is the widest unbreakable word contribution. Text max-content
+is the width of the collapsed text sequence with preserved single spaces
+between emitted words. Atomic inline boxes contribute as unbreakable items to
+their parent's inline intrinsic sizes.
+
+`IntrinsicSizes` remains a content-contribution model. A box's own padding and
+non-negative margins are added only when that box contributes as an atomic item
+to an ancestor's inline formatting context. Its own used content size is still
+resolved as a content box by `crates/layout/src/sizing.rs`.
+
+Replaced control fallbacks may include deterministic UA-like internal control
+chrome, but they must not include author CSS padding. Author padding belongs to
+the normal content-box-to-border-box conversion and to outer contribution
+calculation, so it is applied exactly once.
+
+## Resolver Integration
+
+`inline::refine_layout_with_inline` now materializes intrinsic contributions
+for non-anonymous boxes before building `SizeResolutionInput`.
+
+For block-level and document normal-flow boxes, auto inline size continues to
+stretch to the available inline space as defined by X3.
+
+For atomic inline boxes with `width: auto`, the inline resolver now uses the
+box's intrinsic contributions:
+
+- if available inline content space is definite, the preferred size is the
+  supported shrink-to-fit result: clamp the available content width between
+  min-content and max-content
+- if available inline content space is indefinite, the preferred size is the
+  intrinsic preferred/max-content size
+- if no intrinsic contribution exists, the auto content-based preferred size is
+  zero for the current subset
+
+Explicit `width` continues to override intrinsic preferred width. `min-width`
+and `max-width` still apply after preferred-size selection and before padding
+expands the border-box geometry.
+
+## Determinism And Tests
+
+X4 adds resolver-level tests for:
+
+- auto atomic inline width using intrinsic max-content when space is larger
+- auto atomic inline shrink-to-fit when available space falls between
+  min-content and max-content
+- auto atomic inline width using intrinsic preferred size when available space
+  is indefinite
+- explicit width overriding intrinsic contributions
+
+X4 adds layout-level regression tests for:
+
+- auto inline-block width coming from text intrinsic width
+- padding expanding intrinsic content width to border-box geometry
+- replaced/control CSS padding being applied once in intrinsic contribution
+  paths
+- auto inline-block shrink-to-fit under constrained available width
+- `max-width` applying after intrinsic preferred-size selection
+- explicit inline-block width overriding intrinsic content width
+
+## Deferred Work
+
+X4 intentionally does not implement:
+
+- CSS percentage parsing or percentage intrinsic behavior
+- intrinsic keywords such as `min-content`, `max-content`, or `fit-content`
+- full CSS text layout and Unicode line-breaking rules
+- hyphenation, soft wrap opportunities beyond the current whitespace subset,
+  or `white-space` modes
+- full CSS 2.1 shrink-to-fit equations for every formatting context
+- border and `box-sizing` participation
+- min-height and max-height
+- replaced-element sizing migration entirely into the shared resolver
+- floats, positioning, flex, grid, table, orthogonal writing modes, or
+  fragmentation sizing
+
+Later milestones must extend this intrinsic pass deliberately instead of
+reintroducing ad hoc content-size guesses in layout traversal code.
+
+## Exit Contract
+
+X4 is complete while these remain true:
+
+- supported content types produce deterministic intrinsic inline-size
+  contributions
+- `SizeResolutionInput` receives non-zero intrinsic sizes where supported
+- auto atomic inline width resolution uses intrinsic contributions
+- explicit width and min/max-width remain authoritative in the right order
+- representative resolver and layout regression tests pass


### PR DESCRIPTION
Resolves #837 
Resolves #838 

X3 is complete.

Borrowser now resolves supported normal-flow width and height through the
structured Milestone X sizing model. The layout crate provides explicit
normal-flow inline/block resolver entry points that consume `SizeResolutionInput`
and produce deterministic content-box used sizes plus border-box geometry sizes.

Within the supported subset, CSS width and height now behave as content-box
sizes, padding expands final geometry, auto block-level width fills available
inline space after padding, auto height is content-derived, explicit height
overrides content-derived height, min/max-width constraints apply before padding
expansion, anonymous generated boxes use zero sizing metrics, and descendant
available width is derived from parent content width.

Atomic inline boxes now report definite available-space clamping distinctly from
style max-width constraints, and indefinite available inline sizes no longer
synthesize a zero-width clamp.

The normal-flow refinement pass now uses the resolver as the authoritative
source for `LayoutBox` width and height instead of relying on ad hoc viewport
or inherited-width assumptions. Resolver-level and layout-level regression tests
cover representative explicit, auto, constrained, nested, anonymous, and atomic
inline sizing scenarios.

Deferred work remains percentage parsing, percentage sizing in live layout,
min/max-height, borders, box-sizing, margin auto distribution, full CSS 2.1
block width equations, intrinsic shrink-to-fit, replaced-element resolver
migration, and advanced layout-mode sizing.