### PR TITLE
AD3: centralize CSS-wide keyword handling in CSS

### DIFF
--- a/crates/css/src/cascade.rs
+++ b/crates/css/src/cascade.rs
@@ -52,9 +52,9 @@ pub use contract::{
 
 // Resolved-style contract
 pub use contract::{
-    ResolvedStyle, ResolvedStyleBuildError, ResolvedStyleBuilder, ResolvedStyleEntry,
-    ResolvedValueSource, resolve_cascade_style, resolve_cascade_style_from_rule_inputs,
-    resolve_initial_style,
+    CssWideResolvedSource, ResolvedStyle, ResolvedStyleBuildError, ResolvedStyleBuilder,
+    ResolvedStyleEntry, ResolvedValueSource, resolve_cascade_style,
+    resolve_cascade_style_from_rule_inputs, resolve_initial_style,
 };
 
 // Document-level structured output

--- a/crates/css/src/cascade/contract.rs
+++ b/crates/css/src/cascade/contract.rs
@@ -22,9 +22,9 @@ pub use properties::{
     InitialStyleValue, cascade_property_registry,
 };
 pub use resolved_style::{
-    ResolvedStyle, ResolvedStyleBuildError, ResolvedStyleBuilder, ResolvedStyleEntry,
-    ResolvedValueSource, resolve_cascade_style, resolve_cascade_style_from_rule_inputs,
-    resolve_initial_style,
+    CssWideResolvedSource, ResolvedStyle, ResolvedStyleBuildError, ResolvedStyleBuilder,
+    ResolvedStyleEntry, ResolvedValueSource, resolve_cascade_style,
+    resolve_cascade_style_from_rule_inputs, resolve_initial_style,
 };
 pub use rules::{CascadeRuleInput, CascadeRuleInputBuildError};
 pub use snapshot::cascade_evaluation_debug_snapshot;

--- a/crates/css/src/cascade/contract/declarations.rs
+++ b/crates/css/src/cascade/contract/declarations.rs
@@ -1,5 +1,8 @@
 use crate::model::DeclarationValue;
-use crate::specified::{SpecifiedPropertyValue, SpecifiedValueParseError};
+use crate::specified::{
+    SpecifiedDeclarationValue, SpecifiedPropertyValue, SpecifiedValueParseError,
+};
+use crate::values::CssWideKeywordValue;
 
 use super::priority::CascadeImportance;
 use super::properties::CascadePropertyId;
@@ -94,11 +97,17 @@ impl CascadeSpecifiedValue {
         property: CascadePropertyId,
         value: &DeclarationValue,
     ) -> Result<Self, SpecifiedValueParseError> {
-        Ok(Self {
-            value: CascadeSpecifiedValueRepr::Parsed(SpecifiedPropertyValue::parse(
-                property, value,
-            )?),
-        })
+        match SpecifiedDeclarationValue::parse(property, value)? {
+            SpecifiedDeclarationValue::Property(value) => Ok(Self {
+                value: CascadeSpecifiedValueRepr::Parsed(value),
+            }),
+            SpecifiedDeclarationValue::CssWideKeyword { property, value } => Ok(Self {
+                value: CascadeSpecifiedValueRepr::CssWideKeyword(CascadeCssWideSpecifiedValue {
+                    property,
+                    value,
+                }),
+            }),
+        }
     }
 
     /// Preserves declaration value text for declarations that are not eligible
@@ -115,17 +124,33 @@ impl CascadeSpecifiedValue {
     pub fn parsed(&self) -> Option<&SpecifiedPropertyValue> {
         match &self.value {
             CascadeSpecifiedValueRepr::Parsed(value) => Some(value),
+            CascadeSpecifiedValueRepr::CssWideKeyword(_) => None,
+            CascadeSpecifiedValueRepr::Preserved(_) => None,
+        }
+    }
+
+    pub fn css_wide_keyword(&self) -> Option<CssWideKeywordValue> {
+        match &self.value {
+            CascadeSpecifiedValueRepr::Parsed(_) => None,
+            CascadeSpecifiedValueRepr::CssWideKeyword(value) => Some(value.value),
             CascadeSpecifiedValueRepr::Preserved(_) => None,
         }
     }
 
     pub fn property(&self) -> Option<CascadePropertyId> {
-        self.parsed().map(SpecifiedPropertyValue::property)
+        match &self.value {
+            CascadeSpecifiedValueRepr::Parsed(value) => Some(value.property()),
+            CascadeSpecifiedValueRepr::CssWideKeyword(value) => Some(value.property),
+            CascadeSpecifiedValueRepr::Preserved(_) => None,
+        }
     }
 
     pub fn to_css_text(&self) -> Option<String> {
         match &self.value {
             CascadeSpecifiedValueRepr::Parsed(value) => Some(value.to_css_text()),
+            CascadeSpecifiedValueRepr::CssWideKeyword(value) => {
+                Some(value.value.to_css_text().to_string())
+            }
             CascadeSpecifiedValueRepr::Preserved(value) => value.css_text.clone(),
         }
     }
@@ -134,7 +159,14 @@ impl CascadeSpecifiedValue {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum CascadeSpecifiedValueRepr {
     Parsed(SpecifiedPropertyValue),
+    CssWideKeyword(CascadeCssWideSpecifiedValue),
     Preserved(PreservedCascadeSpecifiedValue),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CascadeCssWideSpecifiedValue {
+    property: CascadePropertyId,
+    value: CssWideKeywordValue,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/css/src/cascade/contract/resolved_style.rs
+++ b/crates/css/src/cascade/contract/resolved_style.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::property_registry;
+use crate::values::CssWideKeyword;
 
 use super::properties::{CascadeInheritance, CascadePropertyId, InitialStyleValue};
 use super::rules::CascadeRuleInput;
@@ -21,6 +22,45 @@ pub enum ResolvedValueSource {
     /// for inherited properties resolves through `Initial(...)` instead.
     Inherited,
     Initial(InitialStyleValue),
+    CssWideKeyword(CssWideResolvedSource),
+}
+
+/// Resolved behavior for one explicit winning CSS-wide keyword declaration.
+///
+/// This preserves authored winner provenance while making the cascade-owned
+/// semantic decision explicit before computed-style materialization.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CssWideResolvedSource {
+    Initial {
+        keyword: CssWideKeyword,
+        winner: CascadeWinner,
+        initial: InitialStyleValue,
+    },
+    Inherited {
+        keyword: CssWideKeyword,
+        winner: CascadeWinner,
+    },
+}
+
+impl CssWideResolvedSource {
+    pub fn keyword(&self) -> CssWideKeyword {
+        match self {
+            Self::Initial { keyword, .. } | Self::Inherited { keyword, .. } => *keyword,
+        }
+    }
+
+    pub fn winner(&self) -> &CascadeWinner {
+        match self {
+            Self::Initial { winner, .. } | Self::Inherited { winner, .. } => winner,
+        }
+    }
+
+    pub fn initial(&self) -> Option<InitialStyleValue> {
+        match self {
+            Self::Initial { initial, .. } => Some(*initial),
+            Self::Inherited { .. } => None,
+        }
+    }
 }
 
 /// One supported property in a resolved style object.
@@ -42,7 +82,9 @@ impl ResolvedStyleEntry {
     pub fn winner(&self) -> Option<&CascadeWinner> {
         match &self.source {
             ResolvedValueSource::Winner(winner) => Some(winner),
-            ResolvedValueSource::Inherited | ResolvedValueSource::Initial(_) => None,
+            ResolvedValueSource::Inherited
+            | ResolvedValueSource::Initial(_)
+            | ResolvedValueSource::CssWideKeyword(_) => None,
         }
     }
 }
@@ -108,7 +150,15 @@ pub fn resolve_cascade_style(
 
     for property in property_registry().ids() {
         if let Some(winner) = winners.get(property) {
-            builder.record_winner(property, winner.clone());
+            match winner.value.css_wide_keyword() {
+                Some(keyword) => builder.record_css_wide_keyword(
+                    property,
+                    winner.clone(),
+                    keyword.keyword(),
+                    parent_style.is_some(),
+                ),
+                None => builder.record_winner(property, winner.clone()),
+            }
             continue;
         }
 
@@ -214,6 +264,43 @@ impl ResolvedStyleBuilder {
         );
     }
 
+    pub fn record_css_wide_keyword(
+        &mut self,
+        property: CascadePropertyId,
+        winner: CascadeWinner,
+        keyword: CssWideKeyword,
+        has_parent_style: bool,
+    ) {
+        let source = match keyword {
+            CssWideKeyword::Initial => css_wide_initial_source(property, keyword, winner),
+            CssWideKeyword::Inherit if has_parent_style => {
+                css_wide_inherited_source(keyword, winner)
+            }
+            CssWideKeyword::Inherit => css_wide_initial_source(property, keyword, winner),
+            CssWideKeyword::Unset
+                if property.metadata().inheritance == CascadeInheritance::Inherited
+                    && has_parent_style =>
+            {
+                css_wide_inherited_source(keyword, winner)
+            }
+            CssWideKeyword::Unset => css_wide_initial_source(property, keyword, winner),
+            CssWideKeyword::Revert | CssWideKeyword::RevertLayer => {
+                panic!(
+                    "unsupported CSS-wide keyword '{}' must be rejected before resolved style",
+                    keyword.as_css_keyword()
+                )
+            }
+        };
+
+        let previous = self
+            .entries
+            .insert(property, ResolvedValueSource::CssWideKeyword(source));
+        assert!(
+            previous.is_none(),
+            "resolved style must not record the same property twice"
+        );
+    }
+
     pub fn build(self) -> Result<ResolvedStyle, ResolvedStyleBuildError> {
         let missing_properties = property_registry()
             .ids()
@@ -232,4 +319,23 @@ impl ResolvedStyleBuilder {
                 .collect(),
         })
     }
+}
+
+fn css_wide_initial_source(
+    property: CascadePropertyId,
+    keyword: CssWideKeyword,
+    winner: CascadeWinner,
+) -> CssWideResolvedSource {
+    CssWideResolvedSource::Initial {
+        keyword,
+        winner,
+        initial: property.initial_value(),
+    }
+}
+
+fn css_wide_inherited_source(
+    keyword: CssWideKeyword,
+    winner: CascadeWinner,
+) -> CssWideResolvedSource {
+    CssWideResolvedSource::Inherited { keyword, winner }
 }

--- a/crates/css/src/cascade/contract/snapshot.rs
+++ b/crates/css/src/cascade/contract/snapshot.rs
@@ -4,7 +4,7 @@ use super::declarations::{
     CascadeDeclarationApplicability, CascadeDeclarationProperty, CascadeSpecifiedValue,
 };
 use super::priority::{CascadeImportance, CascadeOrigin, CascadeSpecificity};
-use super::resolved_style::{ResolvedStyle, ResolvedValueSource};
+use super::resolved_style::{CssWideResolvedSource, ResolvedStyle, ResolvedValueSource};
 use super::rules::CascadeRuleInput;
 use super::sources::{CascadeDeclarationSource, CascadeRuleSource};
 use super::winners::{
@@ -149,6 +149,27 @@ fn source_snapshot_label(source: &ResolvedValueSource) -> String {
         ResolvedValueSource::Initial(initial) => {
             format!("initial({})", initial.as_debug_label())
         }
+        ResolvedValueSource::CssWideKeyword(source) => css_wide_source_snapshot_label(source),
+    }
+}
+
+fn css_wide_source_snapshot_label(source: &CssWideResolvedSource) -> String {
+    match source {
+        CssWideResolvedSource::Initial {
+            keyword,
+            winner,
+            initial,
+        } => format!(
+            "css-wide-initial(keyword={}, {}, initial={})",
+            keyword.as_css_keyword(),
+            winner_snapshot_label(winner),
+            initial.as_debug_label(),
+        ),
+        CssWideResolvedSource::Inherited { keyword, winner } => format!(
+            "css-wide-inherited(keyword={}, {})",
+            keyword.as_css_keyword(),
+            winner_snapshot_label(winner),
+        ),
     }
 }
 

--- a/crates/css/src/cascade/contract/tests/resolved_style.rs
+++ b/crates/css/src/cascade/contract/tests/resolved_style.rs
@@ -1,7 +1,7 @@
 use super::super::{
     CascadeDeclarationInput, CascadeDeclarationSource, CascadeImportance, CascadeOrigin,
     CascadeOriginBand, CascadePriority, CascadePropertyId, CascadeRuleContext, CascadeRuleInput,
-    CascadeSpecificity, CascadeWinner, CascadeWinnerSet, InitialStyleValue,
+    CascadeSpecificity, CascadeWinner, CascadeWinnerSet, CssWideResolvedSource, InitialStyleValue,
     InlineStyleDeclarationRef, InlineStyleRuleRef, ResolvedStyleBuilder, ResolvedValueSource,
     StylesheetDeclarationRef, resolve_cascade_style, resolve_cascade_style_from_rule_inputs,
     resolve_cascade_winners, resolve_initial_style,
@@ -215,6 +215,186 @@ fn resolve_cascade_style_defaults_missing_properties_to_the_initial_contract() {
             .source(),
         &ResolvedValueSource::Initial(InitialStyleValue::NoneKeyword)
     );
+}
+
+#[test]
+fn resolve_cascade_style_resolves_explicit_css_wide_keywords_after_winner_selection() {
+    let mut parent_builder =
+        builder_with_initials_except(&[CascadePropertyId::Color, CascadePropertyId::Display]);
+    parent_builder.record_winner(
+        CascadePropertyId::Color,
+        CascadeWinner {
+            source: stylesheet_declaration_source(0, 0, 0),
+            priority: CascadePriority::new(
+                CascadeOriginBand::AuthorNormal,
+                CascadeSpecificity::Selector(Specificity::TYPE),
+                0,
+                0,
+            ),
+            value: parsed_value("color: red"),
+        },
+    );
+    parent_builder.record_winner(
+        CascadePropertyId::Display,
+        CascadeWinner {
+            source: stylesheet_declaration_source(0, 0, 1),
+            priority: CascadePriority::new(
+                CascadeOriginBand::AuthorNormal,
+                CascadeSpecificity::Selector(Specificity::TYPE),
+                0,
+                1,
+            ),
+            value: parsed_value("display: block"),
+        },
+    );
+    let parent_style = parent_builder.build().expect("total parent style");
+    let child_winners = resolve_cascade_winners(&[
+        CascadeDeclarationInput::supported(
+            stylesheet_declaration_source(0, 1, 0),
+            0,
+            CascadeImportance::Normal,
+            CascadePropertyId::Color,
+            parsed_value("color: unset"),
+        )
+        .candidate(CascadeRuleContext::new(
+            CascadeOrigin::Author,
+            CascadeSpecificity::Selector(Specificity::TYPE),
+            1,
+        ))
+        .expect("color unset candidate"),
+        CascadeDeclarationInput::supported(
+            stylesheet_declaration_source(0, 1, 1),
+            1,
+            CascadeImportance::Normal,
+            CascadePropertyId::Display,
+            parsed_value("display: inherit"),
+        )
+        .candidate(CascadeRuleContext::new(
+            CascadeOrigin::Author,
+            CascadeSpecificity::Selector(Specificity::TYPE),
+            1,
+        ))
+        .expect("display inherit candidate"),
+        CascadeDeclarationInput::supported(
+            stylesheet_declaration_source(0, 1, 2),
+            2,
+            CascadeImportance::Normal,
+            CascadePropertyId::Width,
+            parsed_value("width: unset"),
+        )
+        .candidate(CascadeRuleContext::new(
+            CascadeOrigin::Author,
+            CascadeSpecificity::Selector(Specificity::TYPE),
+            1,
+        ))
+        .expect("width unset candidate"),
+    ]);
+
+    let child = resolve_cascade_style(&child_winners, Some(&parent_style));
+
+    let ResolvedValueSource::CssWideKeyword(CssWideResolvedSource::Inherited {
+        keyword: color_keyword,
+        ..
+    }) = child.get(CascadePropertyId::Color).expect("color").source()
+    else {
+        panic!("color unset should resolve to explicit CSS-wide inheritance");
+    };
+    assert_eq!(color_keyword.as_css_keyword(), "unset");
+
+    let ResolvedValueSource::CssWideKeyword(CssWideResolvedSource::Inherited {
+        keyword: display_keyword,
+        ..
+    }) = child
+        .get(CascadePropertyId::Display)
+        .expect("display")
+        .source()
+    else {
+        panic!("display inherit should resolve to explicit CSS-wide inheritance");
+    };
+    assert_eq!(display_keyword.as_css_keyword(), "inherit");
+
+    let ResolvedValueSource::CssWideKeyword(CssWideResolvedSource::Initial {
+        keyword: width_keyword,
+        initial,
+        ..
+    }) = child.get(CascadePropertyId::Width).expect("width").source()
+    else {
+        panic!("width unset should resolve to explicit CSS-wide initial");
+    };
+    assert_eq!(width_keyword.as_css_keyword(), "unset");
+    assert_eq!(*initial, InitialStyleValue::AutoKeyword);
+    assert!(
+        child
+            .get(CascadePropertyId::Width)
+            .expect("width")
+            .winner()
+            .is_none(),
+        "explicit CSS-wide source must not look like an ordinary authored winner"
+    );
+
+    let snapshot = child.to_debug_snapshot();
+    assert!(snapshot.contains("color: css-wide-inherited(keyword=unset, winner("));
+    assert!(snapshot.contains("display: css-wide-inherited(keyword=inherit, winner("));
+    assert!(snapshot.contains("width: css-wide-initial(keyword=unset, winner("));
+}
+
+#[test]
+fn resolve_cascade_style_resolves_root_css_wide_inherit_and_unset_to_initial() {
+    let root_winners = resolve_cascade_winners(&[
+        CascadeDeclarationInput::supported(
+            stylesheet_declaration_source(0, 0, 0),
+            0,
+            CascadeImportance::Normal,
+            CascadePropertyId::Color,
+            parsed_value("color: inherit"),
+        )
+        .candidate(CascadeRuleContext::new(
+            CascadeOrigin::Author,
+            CascadeSpecificity::Selector(Specificity::TYPE),
+            0,
+        ))
+        .expect("color inherit candidate"),
+        CascadeDeclarationInput::supported(
+            stylesheet_declaration_source(0, 0, 1),
+            1,
+            CascadeImportance::Normal,
+            CascadePropertyId::FontSize,
+            parsed_value("font-size: unset"),
+        )
+        .candidate(CascadeRuleContext::new(
+            CascadeOrigin::Author,
+            CascadeSpecificity::Selector(Specificity::TYPE),
+            0,
+        ))
+        .expect("font-size unset candidate"),
+    ]);
+
+    let root = resolve_cascade_style(&root_winners, None);
+
+    let ResolvedValueSource::CssWideKeyword(CssWideResolvedSource::Initial {
+        keyword: color_keyword,
+        initial: color_initial,
+        ..
+    }) = root.get(CascadePropertyId::Color).expect("color").source()
+    else {
+        panic!("root color inherit should resolve to explicit CSS-wide initial");
+    };
+    assert_eq!(color_keyword.as_css_keyword(), "inherit");
+    assert_eq!(*color_initial, InitialStyleValue::ColorBlack);
+
+    let ResolvedValueSource::CssWideKeyword(CssWideResolvedSource::Initial {
+        keyword: font_keyword,
+        initial: font_initial,
+        ..
+    }) = root
+        .get(CascadePropertyId::FontSize)
+        .expect("font-size")
+        .source()
+    else {
+        panic!("root font-size unset should resolve to explicit CSS-wide initial");
+    };
+    assert_eq!(font_keyword.as_css_keyword(), "unset");
+    assert_eq!(*font_initial, InitialStyleValue::FontSizePx16);
 }
 
 #[test]

--- a/crates/css/src/cascade/contract/tests/rule_inputs.rs
+++ b/crates/css/src/cascade/contract/tests/rule_inputs.rs
@@ -7,8 +7,8 @@ use super::support::{
     inline_declaration_source, matched_rule, parse_error, parsed_value, preserved_value,
     stylesheet_declaration_source,
 };
-use crate::SpecifiedValueParseErrorKind;
 use crate::selectors::Specificity;
+use crate::{CssWideKeyword, SpecifiedValueParseErrorKind};
 
 #[test]
 fn cascade_rule_match_uses_highest_selector_specificity() {
@@ -192,6 +192,61 @@ fn cascade_rule_input_keeps_declaration_filter_state_explicit() {
     assert_eq!(
         candidates[0].priority(),
         context.priority_for_declaration(CascadeImportance::Normal, 0)
+    );
+}
+
+#[test]
+fn cascade_rule_input_keeps_supported_css_wide_keywords_as_candidates() {
+    let inline_style = InlineStyleRuleRef::new(9);
+    let rule = CascadeRuleInput::from_inline_style(
+        inline_style,
+        0,
+        vec![
+            CascadeDeclarationInput::supported(
+                inline_declaration_source(inline_style, 0),
+                0,
+                CascadeImportance::Normal,
+                CascadePropertyId::Color,
+                parsed_value("color: initial"),
+            ),
+            CascadeDeclarationInput::invalid_value(
+                inline_declaration_source(inline_style, 1),
+                1,
+                CascadeImportance::Normal,
+                CascadePropertyId::Color,
+                parse_error(CascadePropertyId::Color, "color: revert"),
+                preserved_value("color: revert"),
+            ),
+        ],
+    )
+    .expect("valid inline style rule");
+
+    assert_eq!(
+        rule.declarations()[0].applicability(),
+        CascadeDeclarationApplicability::Supported(CascadePropertyId::Color)
+    );
+    assert_eq!(
+        rule.declarations()[0]
+            .value()
+            .css_wide_keyword()
+            .expect("css-wide keyword")
+            .keyword(),
+        CssWideKeyword::Initial
+    );
+    assert_eq!(
+        rule.declarations()[1]
+            .invalid_value_error()
+            .expect("invalid value error")
+            .kind(),
+        SpecifiedValueParseErrorKind::UnsupportedCssWideKeyword
+    );
+
+    let candidates = rule.candidates();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].property(), CascadePropertyId::Color);
+    assert_eq!(
+        candidates[0].value().to_css_text().as_deref(),
+        Some("initial")
     );
 }
 

--- a/crates/css/src/cascade/contract/tests/winners.rs
+++ b/crates/css/src/cascade/contract/tests/winners.rs
@@ -349,6 +349,48 @@ fn cascade_winner_resolution_prefers_later_declaration_order_within_one_rule() {
 }
 
 #[test]
+fn cascade_winner_resolution_orders_css_wide_keywords_like_other_supported_values() {
+    let rule = CascadeRuleInput::from_stylesheet_match(
+        &matched_rule(0, 0, &[Specificity::TYPE]),
+        CascadeOrigin::Author,
+        0,
+        vec![
+            CascadeDeclarationInput::supported(
+                stylesheet_declaration_source(0, 0, 0),
+                0,
+                CascadeImportance::Normal,
+                CascadePropertyId::Color,
+                parsed_value("color: red"),
+            ),
+            CascadeDeclarationInput::supported(
+                stylesheet_declaration_source(0, 0, 1),
+                1,
+                CascadeImportance::Normal,
+                CascadePropertyId::Color,
+                parsed_value("color: initial"),
+            ),
+        ],
+    )
+    .expect("valid rule")
+    .expect("matching rule");
+
+    let winners = resolve_cascade_winners_from_rule_inputs(&[rule]);
+    let winner = winners.get(CascadePropertyId::Color).expect("color winner");
+
+    assert_eq!(winner.value.to_css_text().as_deref(), Some("initial"));
+    assert_eq!(
+        winner
+            .value
+            .css_wide_keyword()
+            .expect("css-wide winner")
+            .keyword()
+            .as_css_keyword(),
+        "initial"
+    );
+    assert_eq!(winner.priority.declaration_order, 1);
+}
+
+#[test]
 fn cascade_winner_resolution_ignores_unsupported_custom_and_invalid_declarations() {
     let inline_style = InlineStyleRuleRef::new(12);
     let rule = CascadeRuleInput::from_inline_style(

--- a/crates/css/src/cascade/tests/snapshots.rs
+++ b/crates/css/src/cascade/tests/snapshots.rs
@@ -171,3 +171,22 @@ fn document_style_resolution_debug_snapshot_covers_override_inheritance_and_defa
         )
     );
 }
+
+#[test]
+fn document_style_resolution_keeps_unknown_properties_with_css_wide_values_unsupported() {
+    let stylesheets = vec![stylesheet("div { zoom: initial; color: red; }")];
+    let dom = element("div", Vec::new(), Vec::new());
+
+    let snapshot = resolve_document_styles_debug_snapshot(&dom, &stylesheets);
+
+    assert!(
+        snapshot.contains(
+            "property=unsupported(\"zoom\") applicability=unsupported-property value=\"initial\""
+        ),
+        "{snapshot}"
+    );
+    assert!(
+        snapshot.contains("color: winner("),
+        "known supported declarations should still resolve: {snapshot}"
+    );
+}

--- a/crates/css/src/computed/document/materialize.rs
+++ b/crates/css/src/computed/document/materialize.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     PropertyId, PropertyInheritance,
-    cascade::{ResolvedStyle, ResolvedValueSource},
+    cascade::{CssWideResolvedSource, ResolvedStyle, ResolvedValueSource},
     property_registry,
 };
 
@@ -82,6 +82,35 @@ fn computed_value_from_resolved_source(
             }
 
             Ok(ComputedValue::from_initial(property))
+        }
+        ResolvedValueSource::CssWideKeyword(source) => {
+            computed_value_from_resolved_css_wide_source(property, source, parent_style)
+        }
+    }
+}
+
+fn computed_value_from_resolved_css_wide_source(
+    property: PropertyId,
+    source: &CssWideResolvedSource,
+    parent_style: Option<&ComputedStyle>,
+) -> Result<ComputedValue, ComputedStyleResolutionError> {
+    match source {
+        CssWideResolvedSource::Initial { initial, .. } => {
+            let expected = property.initial_value();
+            if *initial != expected {
+                return Err(ComputedStyleResolutionError::InitialValueMismatch {
+                    property,
+                    expected,
+                    actual: *initial,
+                });
+            }
+
+            Ok(ComputedValue::from_initial(property))
+        }
+        CssWideResolvedSource::Inherited { .. } => {
+            let parent = parent_style
+                .ok_or(ComputedStyleResolutionError::MissingInheritedParent { property })?;
+            Ok(parent.get(property).value())
         }
     }
 }

--- a/crates/css/src/computed/tests/document.rs
+++ b/crates/css/src/computed/tests/document.rs
@@ -72,6 +72,52 @@ fn compute_document_styles_integrates_cascade_inheritance_defaults_and_computati
 }
 
 #[test]
+fn compute_document_styles_materializes_resolved_css_wide_keywords() {
+    let stylesheets = vec![stylesheet(concat!(
+        "section { color: red; font-size: 20px; width: 40px; display: block; }",
+        "span { color: unset; font-size: inherit; width: inherit; display: initial; }",
+    ))];
+    let dom = element(
+        "section",
+        Vec::new(),
+        vec![element("span", Vec::new(), Vec::new())],
+    );
+
+    let computed = compute_document_styles(&dom, &stylesheets).expect("computed document");
+    let section = computed.entries()[0].style();
+    let span = computed.entries()[1].style();
+
+    assert_eq!(section.color(), (255, 0, 0, 255));
+    assert_eq!(section.font_size(), Length::Px(20.0));
+    assert_eq!(
+        section.width(),
+        Some(LengthPercentage::Length(Length::Px(40.0)))
+    );
+    assert_eq!(section.display(), Display::Block);
+
+    assert_eq!(span.color(), section.color());
+    assert_eq!(span.font_size(), section.font_size());
+    assert_eq!(span.width(), section.width());
+    assert_eq!(span.display(), Display::Inline);
+}
+
+#[test]
+fn compute_document_styles_materializes_root_css_wide_fallbacks_to_initial() {
+    let stylesheets = vec![stylesheet(
+        "div { color: inherit; font-size: unset; width: inherit; display: unset; }",
+    )];
+    let dom = element("div", Vec::new(), Vec::new());
+
+    let computed = compute_document_styles(&dom, &stylesheets).expect("computed document");
+    let style = computed.entries()[0].style();
+
+    assert_eq!(style.color(), (0, 0, 0, 255));
+    assert_eq!(style.font_size(), Length::Px(16.0));
+    assert_eq!(style.width(), None);
+    assert_eq!(style.display(), Display::Inline);
+}
+
+#[test]
 fn computed_document_style_layout_impact_distinguishes_paint_layout_and_unknown() {
     let dom = element(
         "section",

--- a/crates/css/src/lib.rs
+++ b/crates/css/src/lib.rs
@@ -39,7 +39,7 @@ pub use cascade::{
     CascadePropertyRegistration, CascadePropertyRegistry, CascadeRuleContext, CascadeRuleInput,
     CascadeRuleInputBuildError, CascadeRuleMatch, CascadeRuleSource, CascadeSpecificity,
     CascadeSpecifiedValue, CascadeWinner, CascadeWinnerEntry, CascadeWinnerSet,
-    CurrentScopeCascadePriorityBand, IncrementalResolvedDocumentStyle,
+    CssWideResolvedSource, CurrentScopeCascadePriorityBand, IncrementalResolvedDocumentStyle,
     IncrementalStyleResolutionStats, InitialStyleValue, InlineStyleDeclarationRef,
     InlineStyleRuleRef, ResolvedDocumentStyle, ResolvedElementStyle, ResolvedStyle,
     ResolvedStyleBuildError, ResolvedStyleBuilder, ResolvedStyleEntry, ResolvedValueSource,
@@ -99,14 +99,16 @@ pub use selectors::{
 };
 pub use specified::{
     SpecifiedBorderStyle, SpecifiedBorderStyleKeyword, SpecifiedColor, SpecifiedColorKeyword,
-    SpecifiedColorSyntax, SpecifiedDisplay, SpecifiedDisplayKeyword, SpecifiedHexColor,
-    SpecifiedLength, SpecifiedLengthPercentage, SpecifiedLengthPercentageOrAuto,
+    SpecifiedColorSyntax, SpecifiedDeclarationValue, SpecifiedDisplay, SpecifiedDisplayKeyword,
+    SpecifiedHexColor, SpecifiedLength, SpecifiedLengthPercentage, SpecifiedLengthPercentageOrAuto,
     SpecifiedLengthPercentageOrNone, SpecifiedLengthUnit, SpecifiedOutlineStyle,
     SpecifiedOutlineStyleKeyword, SpecifiedOverflow, SpecifiedOverflowKeyword, SpecifiedPercentage,
     SpecifiedPosition, SpecifiedPositionKeyword, SpecifiedPropertyValue,
     SpecifiedTextDecorationLine, SpecifiedTextDecorationLineKeyword, SpecifiedValue,
     SpecifiedValueLimits, SpecifiedValueParseError, SpecifiedValueParseErrorKind, SpecifiedZIndex,
-    SpecifiedZIndexValue, parse_specified_value, parse_specified_value_with_limits,
+    SpecifiedZIndexValue, parse_specified_declaration_value,
+    parse_specified_declaration_value_with_limits, parse_specified_value,
+    parse_specified_value_with_limits,
 };
 
 // Explicit syntax-layer surface for parser/tokenizer work and syntax tests.
@@ -152,7 +154,7 @@ pub use syntax::serialize_compat_stylesheet_for_snapshot;
 pub use values::{
     BorderStyle, CssColorKeyword, CssColorSyntax, CssColorValue, CssFunctionValue, CssHexColor,
     CssIntegerValue, CssKeywordValue, CssLengthPercentageValue, CssLengthUnit, CssLengthValue,
-    CssNumberScalar, CssNumberValue, CssPercentageValue, CssStringValue, CssUrlValue, Display,
-    Length, LengthPercentage, OutlineStyle, Overflow, Percentage, Position, TextDecorationLine,
-    ZIndex, parse_color, parse_length,
+    CssNumberScalar, CssNumberValue, CssPercentageValue, CssStringValue, CssUrlValue,
+    CssWideKeyword, CssWideKeywordValue, Display, Length, LengthPercentage, OutlineStyle, Overflow,
+    Percentage, Position, TextDecorationLine, ZIndex, parse_color, parse_length,
 };

--- a/crates/css/src/specified/css_wide.rs
+++ b/crates/css/src/specified/css_wide.rs
@@ -1,0 +1,37 @@
+use crate::{
+    model::ValueComponent,
+    properties::PropertyId,
+    values::{CssWideKeyword, CssWideKeywordValue},
+};
+
+use super::{
+    core::keyword_value,
+    error::{SpecifiedValueParseError, SpecifiedValueParseErrorKind, error},
+};
+
+/// Parses a CSS-wide keyword from one declaration value component.
+///
+/// Unsupported CSS-wide keywords are still recognized here and rejected with a
+/// dedicated error so they cannot be confused with property-specific unknown
+/// keywords.
+pub(super) fn parse_supported_css_wide_keyword(
+    property: PropertyId,
+    component: &ValueComponent,
+) -> Result<Option<CssWideKeywordValue>, SpecifiedValueParseError> {
+    let Some(keyword) = keyword_value(property, component)? else {
+        return Ok(None);
+    };
+
+    let Some(css_wide) = CssWideKeyword::from_canonical(keyword.canonical()) else {
+        return Ok(None);
+    };
+
+    if !css_wide.is_supported_for_current_cascade() {
+        return Err(error(
+            property,
+            SpecifiedValueParseErrorKind::UnsupportedCssWideKeyword,
+        ));
+    }
+
+    Ok(Some(CssWideKeywordValue::new(keyword.span(), css_wide)))
+}

--- a/crates/css/src/specified/error.rs
+++ b/crates/css/src/specified/error.rs
@@ -58,6 +58,7 @@ pub enum SpecifiedValueParseErrorKind {
     NegativeLengthNotAllowed,
     InvariantViolation,
     UnsupportedKeyword,
+    UnsupportedCssWideKeyword,
 }
 
 impl SpecifiedValueParseErrorKind {
@@ -84,6 +85,7 @@ impl SpecifiedValueParseErrorKind {
             Self::NegativeLengthNotAllowed => "negative-length-not-allowed",
             Self::InvariantViolation => "invariant-violation",
             Self::UnsupportedKeyword => "unsupported-keyword",
+            Self::UnsupportedCssWideKeyword => "unsupported-css-wide-keyword",
         }
     }
 }

--- a/crates/css/src/specified/mod.rs
+++ b/crates/css/src/specified/mod.rs
@@ -9,6 +9,7 @@
 mod border;
 mod color;
 mod core;
+mod css_wide;
 mod display;
 mod error;
 mod length;
@@ -21,11 +22,15 @@ mod value;
 mod z_index;
 
 pub use error::{SpecifiedValueParseError, SpecifiedValueParseErrorKind};
-pub use parse::{SpecifiedValueLimits, parse_specified_value, parse_specified_value_with_limits};
+pub use parse::{
+    SpecifiedValueLimits, parse_specified_declaration_value,
+    parse_specified_declaration_value_with_limits, parse_specified_value,
+    parse_specified_value_with_limits,
+};
 pub use value::{
     SpecifiedBorderStyle, SpecifiedBorderStyleKeyword, SpecifiedColor, SpecifiedColorKeyword,
-    SpecifiedColorSyntax, SpecifiedDisplay, SpecifiedDisplayKeyword, SpecifiedHexColor,
-    SpecifiedLength, SpecifiedLengthPercentage, SpecifiedLengthPercentageOrAuto,
+    SpecifiedColorSyntax, SpecifiedDeclarationValue, SpecifiedDisplay, SpecifiedDisplayKeyword,
+    SpecifiedHexColor, SpecifiedLength, SpecifiedLengthPercentage, SpecifiedLengthPercentageOrAuto,
     SpecifiedLengthPercentageOrNone, SpecifiedLengthUnit, SpecifiedOutlineStyle,
     SpecifiedOutlineStyleKeyword, SpecifiedOverflow, SpecifiedOverflowKeyword, SpecifiedPercentage,
     SpecifiedPosition, SpecifiedPositionKeyword, SpecifiedPropertyValue,

--- a/crates/css/src/specified/parse.rs
+++ b/crates/css/src/specified/parse.rs
@@ -6,6 +6,7 @@ use crate::{
 use super::{
     border::parse_border_style,
     color::parse_color,
+    css_wide::parse_supported_css_wide_keyword,
     display::parse_display,
     error::{SpecifiedValueParseError, SpecifiedValueParseErrorKind, error},
     length::{parse_length, parse_length_percentage_or_auto, parse_length_percentage_or_none},
@@ -13,9 +14,33 @@ use super::{
     overflow::parse_overflow,
     position::parse_position,
     text_decoration::parse_text_decoration_line,
-    value::{SpecifiedPropertyValue, SpecifiedValue},
+    value::{SpecifiedDeclarationValue, SpecifiedPropertyValue, SpecifiedValue},
     z_index::parse_z_index,
 };
+
+/// Parses one model-layer declaration value into a declaration-level specified
+/// value, including CSS-wide keywords.
+pub fn parse_specified_declaration_value(
+    property: PropertyId,
+    value: &DeclarationValue,
+) -> Result<SpecifiedDeclarationValue, SpecifiedValueParseError> {
+    parse_specified_declaration_value_with_limits(property, value, &SpecifiedValueLimits::default())
+}
+
+pub fn parse_specified_declaration_value_with_limits(
+    property: PropertyId,
+    value: &DeclarationValue,
+    limits: &SpecifiedValueLimits,
+) -> Result<SpecifiedDeclarationValue, SpecifiedValueParseError> {
+    let component = sole_non_trivia_component(property, value, limits)?;
+    if let Some(value) = parse_supported_css_wide_keyword(property, component)? {
+        return Ok(SpecifiedDeclarationValue::CssWideKeyword { property, value });
+    }
+
+    parse_specified_value_component(property, component).map(|value| {
+        SpecifiedDeclarationValue::Property(SpecifiedPropertyValue { property, value })
+    })
+}
 
 /// Parses one model-layer declaration value into a property-aware specified
 /// value.
@@ -32,6 +57,24 @@ pub fn parse_specified_value_with_limits(
     limits: &SpecifiedValueLimits,
 ) -> Result<SpecifiedPropertyValue, SpecifiedValueParseError> {
     let component = sole_non_trivia_component(property, value, limits)?;
+    let specified = parse_specified_value_component(property, component)?;
+
+    debug_assert_eq!(
+        specified.kind(),
+        property.metadata().specified_value,
+        "specified parser emitted a value kind that does not match property metadata"
+    );
+
+    Ok(SpecifiedPropertyValue {
+        property,
+        value: specified,
+    })
+}
+
+fn parse_specified_value_component(
+    property: PropertyId,
+    component: &ValueComponent,
+) -> Result<SpecifiedValue, SpecifiedValueParseError> {
     let specified = match property.metadata().specified_value {
         PropertySpecifiedValueKind::BorderStyleKeyword => {
             SpecifiedValue::BorderStyle(parse_border_style(property, component)?)
@@ -78,10 +121,7 @@ pub fn parse_specified_value_with_limits(
         "specified parser emitted a value kind that does not match property metadata"
     );
 
-    Ok(SpecifiedPropertyValue {
-        property,
-        value: specified,
-    })
+    Ok(specified)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/css/src/specified/tests.rs
+++ b/crates/css/src/specified/tests.rs
@@ -3,12 +3,12 @@ use super::{
     SpecifiedDisplayKeyword, SpecifiedLengthPercentageOrAuto, SpecifiedLengthUnit,
     SpecifiedOutlineStyleKeyword, SpecifiedOverflowKeyword, SpecifiedPositionKeyword,
     SpecifiedTextDecorationLineKeyword, SpecifiedValue, SpecifiedValueLimits,
-    SpecifiedValueParseErrorKind, SpecifiedZIndexValue, parse_specified_value,
-    parse_specified_value_with_limits,
+    SpecifiedValueParseErrorKind, SpecifiedZIndexValue, parse_specified_declaration_value,
+    parse_specified_value, parse_specified_value_with_limits,
 };
 use crate::{
-    CssLengthPercentageValue, ParseOptions, PropertyId, PropertySpecifiedValueKind, Rule,
-    parse_stylesheet_with_options, property_registry,
+    CssLengthPercentageValue, CssWideKeyword, ParseOptions, PropertyId, PropertySpecifiedValueKind,
+    Rule, parse_stylesheet_with_options, property_registry,
 };
 
 fn declaration_value(css_declaration: &str) -> crate::DeclarationValue {
@@ -28,9 +28,26 @@ fn parse(property: PropertyId, css_declaration: &str) -> super::SpecifiedPropert
         .unwrap_or_else(|error| panic!("failed to parse {css_declaration:?}: {error}"))
 }
 
+fn parse_declaration(
+    property: PropertyId,
+    css_declaration: &str,
+) -> super::SpecifiedDeclarationValue {
+    parse_specified_declaration_value(property, &declaration_value(css_declaration))
+        .unwrap_or_else(|error| panic!("failed to parse {css_declaration:?}: {error}"))
+}
+
 fn parse_error(property: PropertyId, css_declaration: &str) -> SpecifiedValueParseErrorKind {
     parse_specified_value(property, &declaration_value(css_declaration))
         .expect_err("specified value must be rejected")
+        .kind()
+}
+
+fn parse_declaration_error(
+    property: PropertyId,
+    css_declaration: &str,
+) -> SpecifiedValueParseErrorKind {
+    parse_specified_declaration_value(property, &declaration_value(css_declaration))
+        .expect_err("specified declaration value must be rejected")
         .kind()
 }
 
@@ -142,6 +159,41 @@ fn parses_representative_property_aware_specified_values() {
         SpecifiedTextDecorationLineKeyword::Underline
     );
     assert_eq!(text_decoration_line.to_css_text(), "underline");
+}
+
+#[test]
+fn parses_supported_css_wide_keywords_through_shared_declaration_parser() {
+    for (property, declaration, expected) in [
+        (PropertyId::Color, "color: initial", CssWideKeyword::Initial),
+        (
+            PropertyId::Display,
+            "display: INHERIT",
+            CssWideKeyword::Inherit,
+        ),
+        (PropertyId::Width, "width: unset", CssWideKeyword::Unset),
+    ] {
+        let parsed = parse_declaration(property, declaration);
+        let keyword = parsed
+            .css_wide_keyword()
+            .unwrap_or_else(|| panic!("expected CSS-wide keyword for {declaration}"));
+
+        assert_eq!(parsed.property(), property);
+        assert_eq!(keyword.keyword(), expected);
+        assert_eq!(parsed.to_css_text(), expected.as_css_keyword());
+        assert!(parsed.property_value().is_none());
+    }
+}
+
+#[test]
+fn rejects_unsupported_css_wide_keywords_with_dedicated_error() {
+    assert_eq!(
+        parse_declaration_error(PropertyId::Color, "color: revert"),
+        SpecifiedValueParseErrorKind::UnsupportedCssWideKeyword
+    );
+    assert_eq!(
+        parse_declaration_error(PropertyId::Display, "display: revert-layer"),
+        SpecifiedValueParseErrorKind::UnsupportedCssWideKeyword
+    );
 }
 
 #[test]

--- a/crates/css/src/specified/value.rs
+++ b/crates/css/src/specified/value.rs
@@ -5,10 +5,65 @@ use crate::{
     values::{
         CssColorKeyword, CssColorSyntax, CssColorValue, CssHexColor, CssIntegerValue,
         CssLengthPercentageValue, CssLengthUnit, CssLengthValue, CssPercentageValue,
+        CssWideKeywordValue,
     },
 };
 
-use super::{error::SpecifiedValueParseError, parse::parse_specified_value};
+use super::{
+    error::SpecifiedValueParseError,
+    parse::{parse_specified_declaration_value, parse_specified_value},
+};
+
+/// One supported declaration value after property-aware specified parsing.
+///
+/// CSS-wide keywords are represented here as declaration values rather than
+/// property-specific values because cascade winner resolution must compare
+/// them before resolving their inheritance/defaulting behavior.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpecifiedDeclarationValue {
+    Property(SpecifiedPropertyValue),
+    CssWideKeyword {
+        property: PropertyId,
+        value: CssWideKeywordValue,
+    },
+}
+
+impl SpecifiedDeclarationValue {
+    pub fn parse(
+        property: PropertyId,
+        value: &DeclarationValue,
+    ) -> Result<Self, SpecifiedValueParseError> {
+        parse_specified_declaration_value(property, value)
+    }
+
+    pub fn property(&self) -> PropertyId {
+        match self {
+            Self::Property(value) => value.property(),
+            Self::CssWideKeyword { property, .. } => *property,
+        }
+    }
+
+    pub fn property_value(&self) -> Option<&SpecifiedPropertyValue> {
+        match self {
+            Self::Property(value) => Some(value),
+            Self::CssWideKeyword { .. } => None,
+        }
+    }
+
+    pub fn css_wide_keyword(&self) -> Option<CssWideKeywordValue> {
+        match self {
+            Self::Property(_) => None,
+            Self::CssWideKeyword { value, .. } => Some(*value),
+        }
+    }
+
+    pub fn to_css_text(&self) -> String {
+        match self {
+            Self::Property(value) => value.to_css_text(),
+            Self::CssWideKeyword { value, .. } => value.to_css_text().to_string(),
+        }
+    }
+}
 
 /// One parsed specified value for one supported property.
 ///

--- a/crates/css/src/values.rs
+++ b/crates/css/src/values.rs
@@ -29,6 +29,72 @@ impl CssKeywordValue {
     }
 }
 
+/// CSS-wide keyword recognized before property-specific value parsing.
+///
+/// These keywords are declaration-level CSS semantics. They are not ordinary
+/// property-specific keyword values and must be resolved by cascade/defaulting
+/// code after winner selection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CssWideKeyword {
+    Initial,
+    Inherit,
+    Unset,
+    Revert,
+    RevertLayer,
+}
+
+impl CssWideKeyword {
+    pub fn from_canonical(keyword: &str) -> Option<Self> {
+        match keyword {
+            "initial" => Some(Self::Initial),
+            "inherit" => Some(Self::Inherit),
+            "unset" => Some(Self::Unset),
+            "revert" => Some(Self::Revert),
+            "revert-layer" => Some(Self::RevertLayer),
+            _ => None,
+        }
+    }
+
+    pub fn as_css_keyword(self) -> &'static str {
+        match self {
+            Self::Initial => "initial",
+            Self::Inherit => "inherit",
+            Self::Unset => "unset",
+            Self::Revert => "revert",
+            Self::RevertLayer => "revert-layer",
+        }
+    }
+
+    pub fn is_supported_for_current_cascade(self) -> bool {
+        matches!(self, Self::Initial | Self::Inherit | Self::Unset)
+    }
+}
+
+/// One recognized CSS-wide keyword with its authored span.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CssWideKeywordValue {
+    span: CssSpan,
+    keyword: CssWideKeyword,
+}
+
+impl CssWideKeywordValue {
+    pub fn new(span: CssSpan, keyword: CssWideKeyword) -> Self {
+        Self { span, keyword }
+    }
+
+    pub fn span(self) -> CssSpan {
+        self.span
+    }
+
+    pub fn keyword(self) -> CssWideKeyword {
+        self.keyword
+    }
+
+    pub fn to_css_text(self) -> &'static str {
+        self.keyword.as_css_keyword()
+    }
+}
+
 /// Finite CSS number scalar.
 ///
 /// The authored number representation remains separate from this scalar so

--- a/docs/css/ad1-css-value-property-ownership-architecture.md
+++ b/docs/css/ad1-css-value-property-ownership-architecture.md
@@ -154,6 +154,9 @@ AD1 does not implement CSS-wide keywords. Later AD work must define how these
 keywords are represented before and after cascade, how they interact with
 inheritance/defaulting, and which subset is supported.
 
+AD3 implements the current shared CSS-wide keyword contract for supported
+properties. See `docs/css/ad3-css-wide-keyword-handling.md`.
+
 ## Shorthand Expansion
 
 Shorthand expansion is CSS-owned. A supported shorthand declaration must expand

--- a/docs/css/ad2-typed-core-css-value-model.md
+++ b/docs/css/ad2-typed-core-css-value-model.md
@@ -150,3 +150,6 @@ syntax, or function grammars. Those issues must extend the CSS-owned core
 value model, property specified values, computed normalization, docs, and tests
 together. They must not move CSS value parsing into layout, paint, GFX, or
 browser/runtime.
+
+AD3 adds the current CSS-wide keyword representation and handling contract for
+supported properties. See `docs/css/ad3-css-wide-keyword-handling.md`.

--- a/docs/css/ad3-css-wide-keyword-handling.md
+++ b/docs/css/ad3-css-wide-keyword-handling.md
@@ -1,0 +1,137 @@
+# AD3: CSS-Wide Keyword Handling
+
+Last updated: 2026-06-26
+Status: implemented contract for Milestone AD issue 3
+
+This document defines Borrowser's current CSS-owned handling for CSS-wide
+keywords on supported properties.
+
+Related code:
+
+- `crates/css/src/values.rs`
+- `crates/css/src/specified/css_wide.rs`
+- `crates/css/src/specified/parse.rs`
+- `crates/css/src/cascade/contract/declarations.rs`
+- `crates/css/src/cascade/contract/resolved_style.rs`
+- `crates/css/src/computed/document/materialize.rs`
+
+Related documents:
+
+- `docs/css/ad1-css-value-property-ownership-architecture.md`
+- `docs/css/ad2-typed-core-css-value-model.md`
+- `docs/css/s5-invalid-value-handling-fallback.md`
+- `docs/css/r5-inheritance-behavior-supported-properties.md`
+- `docs/css/r6-initial-default-value-handling.md`
+- `docs/css/r9-cascade-invariants-supported-property-behavior-computed-style-handoff.md`
+- `docs/engine-feature-gap-tracker.md`
+
+## Purpose
+
+CSS-wide keywords are declaration-level CSS semantics. They apply across
+supported properties but are not ordinary property-specific values like
+`display: block` or `color: red`.
+
+AD3 introduces a shared CSS-owned representation and parser for:
+
+- `initial`
+- `inherit`
+- `unset`
+- `revert`
+- `revert-layer`
+
+The current implemented subset supports `initial`, `inherit`, and `unset`.
+`revert` and `revert-layer` are centrally recognized but rejected as
+unsupported because correct behavior depends on cascade origin and cascade
+layer semantics beyond the current supported model.
+
+## Representation
+
+`CssWideKeyword` and `CssWideKeywordValue` live in `crates/css/src/values.rs`.
+
+The specified layer exposes `SpecifiedDeclarationValue`, which can hold either:
+
+- a property-specific `SpecifiedPropertyValue`;
+- a CSS-wide keyword for one supported property.
+
+This keeps CSS-wide keyword handling out of individual property parsers.
+Property-specific modules such as `display`, `color`, `length`, `overflow`, and
+`z_index` must not add ad hoc branches for `initial`, `inherit`, `unset`,
+`revert`, or `revert-layer`.
+
+## Parsing
+
+CSS-wide parsing is centralized in `crates/css/src/specified/css_wide.rs`.
+
+The declaration-level parser checks for CSS-wide keywords before dispatching to
+property-specific parsers. Unknown properties are still rejected as unsupported
+properties before value parsing can make them supported. For example,
+`zoom: initial` remains an unsupported property.
+
+Unsupported CSS-wide keywords produce
+`SpecifiedValueParseErrorKind::UnsupportedCssWideKeyword`. This is distinct
+from property-specific unsupported keywords so `revert` and `revert-layer` are
+recognized-but-unsupported, not confused with ordinary invalid values.
+
+## Cascade Behavior
+
+Supported CSS-wide declarations remain supported declaration values through
+normal candidate creation, ordering, and winner selection. They are not
+resolved during token parsing or property-specific parsing.
+
+When a CSS-wide value wins, `resolve_cascade_style(...)` resolves it through
+property metadata:
+
+- `initial` resolves to `property.initial_value()`.
+- `inherit` resolves to explicit inheritance when a parent style is available.
+- root or no-parent `inherit` resolves to the property's initial value.
+- `unset` resolves like `inherit` for inherited-by-default properties when a
+  parent style is available.
+- `unset` resolves like `initial` for non-inherited properties and for
+  inherited properties at the root.
+
+Resolved style stores explicit CSS-wide provenance through
+`ResolvedValueSource::CssWideKeyword(CssWideResolvedSource)`. This keeps
+explicit `color: unset` distinguishable from ordinary missing-property
+inheritance, and explicit `width: initial` distinguishable from ordinary
+default fill.
+
+## Computed-Style Materialization
+
+Computed style consumes already-resolved CSS-wide sources:
+
+- resolved CSS-wide initial sources materialize through
+  `ComputedValue::from_initial(property)`;
+- resolved CSS-wide inherited sources copy the parent computed property value.
+
+The computed layer does not decide what `initial`, `inherit`, or `unset` mean.
+That semantic choice belongs to the CSS cascade/resolved-style layer.
+
+## Unsupported Behavior
+
+`revert` and `revert-layer` are not approximated as `initial`, `inherit`, or
+`unset`.
+
+They remain unsupported until Borrowser has the cascade-origin and cascade-layer
+model needed to implement them correctly.
+
+## Invariants
+
+- CSS-wide parsing is centralized in CSS-owned shared infrastructure.
+- Supported CSS-wide keywords participate in cascade winner selection.
+- Property-specific parsers do not implement CSS-wide keyword branches.
+- Unknown properties do not become supported because their value is CSS-wide.
+- CSS-wide resolution uses CSS-owned property metadata only.
+- Browser/runtime, Layout, Paint, and GFX do not interpret CSS-wide keyword
+  semantics.
+- Debug output preserves explicit CSS-wide provenance.
+
+## Test Surface
+
+AD3 is covered by tests for:
+
+- shared declaration-level CSS-wide parsing;
+- deterministic rejection of unsupported CSS-wide keywords;
+- CSS-wide values participating in cascade candidates and winner resolution;
+- unknown properties with CSS-wide values remaining unsupported;
+- resolved-style provenance for explicit CSS-wide initial/inherited behavior;
+- computed materialization of resolved CSS-wide initial/inherited sources.

--- a/docs/css/r9-cascade-invariants-supported-property-behavior-computed-style-handoff.md
+++ b/docs/css/r9-cascade-invariants-supported-property-behavior-computed-style-handoff.md
@@ -326,7 +326,15 @@ integration settles.
 
 Milestone R does not require pruning that surface preemptively.
 
-### 7. Exact debug snapshots are intentionally high-discipline maintenance surfaces
+### 7. Later AD3 CSS-wide keyword handling
+
+Milestone R did not implement CSS-wide keywords. Milestone AD3 later adds a
+CSS-owned shared representation and parser for CSS-wide keywords on supported
+properties. In the current AD3 contract, `initial`, `inherit`, and `unset`
+participate in cascade winner selection before being resolved through property
+metadata, while `revert` and `revert-layer` remain recognized but unsupported.
+
+### 8. Exact debug snapshots are intentionally high-discipline maintenance surfaces
 
 Milestone R's snapshot surfaces are versioned, deterministic, and treated as
 contract-quality regression outputs. That is the right choice, but it creates a

--- a/docs/css/s5-invalid-value-handling-fallback.md
+++ b/docs/css/s5-invalid-value-handling-fallback.md
@@ -136,6 +136,12 @@ S5 does not implement:
   function values
 - full retirement of the legacy `compute_style(...)` compatibility bridge
 
+Later AD3 adds the current CSS-wide keyword handling contract for supported
+properties. In that contract, supported CSS-wide keywords participate in
+cascade winner selection, while unsupported CSS-wide keywords such as `revert`
+and `revert-layer` are rejected with a dedicated recognized-but-unsupported
+error.
+
 ## Test Surface
 
 S5 adds and relies on tests for:

--- a/docs/engine-feature-gap-tracker.md
+++ b/docs/engine-feature-gap-tracker.md
@@ -59,6 +59,11 @@ Architecture status:
 - AD2 does not add broad CSS Values and Units coverage, new property families,
   URL/resource loading, broad function support, CSS-wide keywords, shorthands,
   or invalidation impact classification.
+- AD3 adds shared CSS-wide keyword handling for supported properties; see
+  `docs/css/ad3-css-wide-keyword-handling.md`. `initial`, `inherit`, and
+  `unset` are supported through cascade winner selection and CSS-owned
+  resolved-style materialization. `revert` and `revert-layer` are recognized
+  but unsupported until cascade origin/layer support exists.
 - Concrete CSS-owned invalidation impact classification for supported
   properties remains future AD7 work.
 


### PR DESCRIPTION
Resolves #1060 