### PR TITLE
AD7: Add CSS-owned invalidation impact classification

### DIFF
--- a/crates/browser/src/page/retained_render_state.rs
+++ b/crates/browser/src/page/retained_render_state.rs
@@ -11,7 +11,7 @@ use crate::rendering::{
     RetainedStyleArtifactDebugSnapshot, RetainedStyleArtifactKey, RetainedStyleArtifactState,
     RetainedStyleArtifactStats, StyleInvalidationState, dirty_request_for_entry_point,
 };
-use css::{ComputedDocumentStyleLayoutImpact, ComputedStyleReuseStats};
+use css::{ComputedDocumentStyleInvalidationImpact, ComputedStyleReuseStats};
 use gfx::paint::PaintArtifact;
 use html::Node;
 use layout::{
@@ -234,12 +234,21 @@ impl RetainedRenderState {
         self.last_style_artifact_action = RetainedStyleArtifactAction::DiscardedForFullInvalidation;
     }
 
-    pub(super) fn record_computed_style_layout_impact(
+    pub(super) fn record_computed_style_invalidation_impact(
         &mut self,
-        impact: ComputedDocumentStyleLayoutImpact,
+        impact: ComputedDocumentStyleInvalidationImpact,
     ) {
         match impact {
-            ComputedDocumentStyleLayoutImpact::PaintOnly => {
+            ComputedDocumentStyleInvalidationImpact::NoVisualImpact
+            | ComputedDocumentStyleInvalidationImpact::StyleOnly => {
+                self.dirty_state
+                    .remove_phase_reason(DirtyPhase::Layout, DirtyReason::CascadedFromStyle);
+                if !self.layout_dirty() {
+                    self.dirty_state
+                        .remove_phase_reason(DirtyPhase::Paint, DirtyReason::CascadedFromLayout);
+                }
+            }
+            ComputedDocumentStyleInvalidationImpact::PaintOnly => {
                 self.generations.paint_style = self
                     .generations
                     .paint_style
@@ -257,8 +266,8 @@ impl RetainedRenderState {
                     DirtyScope::Document,
                 ));
             }
-            ComputedDocumentStyleLayoutImpact::LayoutAffecting
-            | ComputedDocumentStyleLayoutImpact::Unknown => {
+            ComputedDocumentStyleInvalidationImpact::LayoutAffecting
+            | ComputedDocumentStyleInvalidationImpact::Unknown => {
                 self.generations.layout_style = self
                     .generations
                     .layout_style

--- a/crates/browser/src/page/style_phase.rs
+++ b/crates/browser/src/page/style_phase.rs
@@ -1,5 +1,5 @@
 use css::{
-    ComputedDocumentStyleLayoutImpact, ComputedStyleResolutionError, ComputedStyleReuseStats,
+    ComputedDocumentStyleInvalidationImpact, ComputedStyleResolutionError, ComputedStyleReuseStats,
     StylePhaseOutput, build_style_tree_from_computed_styles,
 };
 use gfx::paint::PaintArtifact;
@@ -127,12 +127,12 @@ impl PageState {
             if let Some(previous) = previous_computed.as_ref()
                 && let Some(current) = retained.style_cache.as_ref()
             {
-                retained.record_computed_style_layout_impact(
-                    current.computed.layout_impact_against(previous),
+                retained.record_computed_style_invalidation_impact(
+                    current.computed.invalidation_impact_against(previous),
                 );
             } else if had_cache_before {
-                retained.record_computed_style_layout_impact(
-                    ComputedDocumentStyleLayoutImpact::Unknown,
+                retained.record_computed_style_invalidation_impact(
+                    ComputedDocumentStyleInvalidationImpact::Unknown,
                 );
             }
             retained.record_style_artifact_recompute(style_artifact_action_for_recompute(

--- a/crates/browser/src/rendering/tests/runtime_state.rs
+++ b/crates/browser/src/rendering/tests/runtime_state.rs
@@ -579,6 +579,17 @@ fn stacking_order_affecting_style_change_invalidates_retained_paint() {
         .prepare_style_phase_for_frame(&PendingRenderWork::default())
         .expect("frame preparation should succeed")
         .expect("document should produce a frame");
+    assert!(
+        prepared
+            .work_plan
+            .dirty_state
+            .is_phase_dirty(DirtyPhase::Layout),
+        "paint-order style changes remain conservatively layout-affecting until runtime has narrower retained paint-order invalidation"
+    );
+    assert_eq!(
+        prepared.work_plan.relayout.decision,
+        RenderWorkDecision::Relayout
+    );
     assert_eq!(
         prepared.work_plan.repaint.decision,
         RenderWorkDecision::Repaint

--- a/crates/css/src/computed/impact.rs
+++ b/crates/css/src/computed/impact.rs
@@ -1,63 +1,119 @@
-use crate::properties::{PropertyId, PropertyInvalidationImpact};
+use crate::properties::PropertyId;
 
 use super::document::ComputedDocumentStyle;
 use super::style::ComputedStyle;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ComputedStyleLayoutImpact {
+pub enum ComputedStyleInvalidationImpact {
+    NoVisualImpact,
+    StyleOnly,
     PaintOnly,
     LayoutAffecting,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ComputedDocumentStyleLayoutImpact {
+pub enum ComputedDocumentStyleInvalidationImpact {
+    NoVisualImpact,
+    StyleOnly,
     PaintOnly,
     LayoutAffecting,
     Unknown,
 }
 
 impl ComputedStyle {
-    pub fn layout_impact_against(&self, previous: &Self) -> ComputedStyleLayoutImpact {
+    pub fn invalidation_impact_against(&self, previous: &Self) -> ComputedStyleInvalidationImpact {
+        let mut impact = ComputedStyleInvalidationImpact::NoVisualImpact;
+
         for property in PropertyId::ALL {
-            if self.get(property).value() != previous.get(property).value()
-                && property_layout_impact(property) == ComputedStyleLayoutImpact::LayoutAffecting
-            {
-                return ComputedStyleLayoutImpact::LayoutAffecting;
+            if self.get(property).value() == previous.get(property).value() {
+                continue;
+            }
+
+            impact = impact.combine(property_invalidation_impact(property));
+            if impact == ComputedStyleInvalidationImpact::LayoutAffecting {
+                return impact;
             }
         }
-        ComputedStyleLayoutImpact::PaintOnly
+
+        impact
     }
 }
 
 impl ComputedDocumentStyle {
-    pub fn layout_impact_against(&self, previous: &Self) -> ComputedDocumentStyleLayoutImpact {
+    pub fn invalidation_impact_against(
+        &self,
+        previous: &Self,
+    ) -> ComputedDocumentStyleInvalidationImpact {
         if self.entries().len() != previous.entries().len() {
-            return ComputedDocumentStyleLayoutImpact::Unknown;
+            return ComputedDocumentStyleInvalidationImpact::Unknown;
         }
+
+        let mut impact = ComputedDocumentStyleInvalidationImpact::NoVisualImpact;
 
         for (current, previous) in self.entries().iter().zip(previous.entries()) {
             if current.selector_element_id() != previous.selector_element_id()
                 || current.element_name() != previous.element_name()
             {
-                return ComputedDocumentStyleLayoutImpact::Unknown;
+                return ComputedDocumentStyleInvalidationImpact::Unknown;
             }
 
-            if current.style().layout_impact_against(previous.style())
-                == ComputedStyleLayoutImpact::LayoutAffecting
-            {
-                return ComputedDocumentStyleLayoutImpact::LayoutAffecting;
+            impact = impact.combine(
+                current
+                    .style()
+                    .invalidation_impact_against(previous.style()),
+            );
+            if impact == ComputedDocumentStyleInvalidationImpact::LayoutAffecting {
+                return impact;
             }
         }
 
-        ComputedDocumentStyleLayoutImpact::PaintOnly
+        impact
     }
 }
 
-fn property_layout_impact(property: PropertyId) -> ComputedStyleLayoutImpact {
-    match property.metadata().invalidation_impact {
-        PropertyInvalidationImpact::RepaintOnly => ComputedStyleLayoutImpact::PaintOnly,
-        PropertyInvalidationImpact::RelayoutAndRepaint => {
-            ComputedStyleLayoutImpact::LayoutAffecting
+impl ComputedStyleInvalidationImpact {
+    fn combine(self, next: Self) -> Self {
+        use ComputedStyleInvalidationImpact::{
+            LayoutAffecting, NoVisualImpact, PaintOnly, StyleOnly,
+        };
+
+        match (self, next) {
+            (LayoutAffecting, _) | (_, LayoutAffecting) => LayoutAffecting,
+            (PaintOnly, _) | (_, PaintOnly) => PaintOnly,
+            (StyleOnly, _) | (_, StyleOnly) => StyleOnly,
+            (NoVisualImpact, NoVisualImpact) => NoVisualImpact,
         }
+    }
+}
+
+impl ComputedDocumentStyleInvalidationImpact {
+    fn combine(self, next: ComputedStyleInvalidationImpact) -> Self {
+        use ComputedDocumentStyleInvalidationImpact::{
+            LayoutAffecting, NoVisualImpact, PaintOnly, StyleOnly, Unknown,
+        };
+
+        match (self, next) {
+            (Unknown, _) => Unknown,
+            (LayoutAffecting, _) | (_, ComputedStyleInvalidationImpact::LayoutAffecting) => {
+                LayoutAffecting
+            }
+            (PaintOnly, _) | (_, ComputedStyleInvalidationImpact::PaintOnly) => PaintOnly,
+            (StyleOnly, _) | (_, ComputedStyleInvalidationImpact::StyleOnly) => StyleOnly,
+            (NoVisualImpact, ComputedStyleInvalidationImpact::NoVisualImpact) => NoVisualImpact,
+        }
+    }
+}
+
+fn property_invalidation_impact(property: PropertyId) -> ComputedStyleInvalidationImpact {
+    let impact = property.metadata().invalidation_impact;
+
+    if impact.requires_runtime_layout() {
+        ComputedStyleInvalidationImpact::LayoutAffecting
+    } else if impact.requires_runtime_paint() {
+        ComputedStyleInvalidationImpact::PaintOnly
+    } else if impact.affects_inherited_style() {
+        ComputedStyleInvalidationImpact::StyleOnly
+    } else {
+        ComputedStyleInvalidationImpact::NoVisualImpact
     }
 }

--- a/crates/css/src/computed/mod.rs
+++ b/crates/css/src/computed/mod.rs
@@ -40,7 +40,7 @@ pub use document::{
     compute_style_from_resolved_style,
 };
 pub use format::computed_value_debug_snapshot;
-pub use impact::{ComputedDocumentStyleLayoutImpact, ComputedStyleLayoutImpact};
+pub use impact::{ComputedDocumentStyleInvalidationImpact, ComputedStyleInvalidationImpact};
 pub use legacy::{build_style_tree, compute_style};
 pub use style::{
     BorderEdges, BorderSide, BoxMetrics, ComputedStyle, ComputedStyleBuildError,

--- a/crates/css/src/computed/tests/document.rs
+++ b/crates/css/src/computed/tests/document.rs
@@ -1,7 +1,7 @@
 use super::support::*;
 use super::*;
 use crate::{
-    ComputedDocumentStyleLayoutImpact, StyleResolutionError, StyleResolutionLimit,
+    ComputedDocumentStyleInvalidationImpact, StyleResolutionError, StyleResolutionLimit,
     StyleResolutionLimits,
 };
 
@@ -211,7 +211,7 @@ fn compute_document_styles_materializes_root_css_wide_fallbacks_to_initial() {
 }
 
 #[test]
-fn computed_document_style_layout_impact_distinguishes_paint_layout_and_unknown() {
+fn computed_document_style_invalidation_impact_distinguishes_paint_layout_and_unknown() {
     let dom = element(
         "section",
         Vec::new(),
@@ -230,16 +230,16 @@ fn computed_document_style_layout_impact_distinguishes_paint_layout_and_unknown(
     .expect("different shape computed document");
 
     assert_eq!(
-        paint_only.layout_impact_against(&base),
-        ComputedDocumentStyleLayoutImpact::PaintOnly
+        paint_only.invalidation_impact_against(&base),
+        ComputedDocumentStyleInvalidationImpact::PaintOnly
     );
     assert_eq!(
-        layout_affecting.layout_impact_against(&base),
-        ComputedDocumentStyleLayoutImpact::LayoutAffecting
+        layout_affecting.invalidation_impact_against(&base),
+        ComputedDocumentStyleInvalidationImpact::LayoutAffecting
     );
     assert_eq!(
-        different_shape.layout_impact_against(&base),
-        ComputedDocumentStyleLayoutImpact::Unknown
+        different_shape.invalidation_impact_against(&base),
+        ComputedDocumentStyleInvalidationImpact::Unknown
     );
 }
 

--- a/crates/css/src/computed/tests/style.rs
+++ b/crates/css/src/computed/tests/style.rs
@@ -1,6 +1,6 @@
 use super::support::*;
 use super::*;
-use crate::{BorderSide, ComputedStyleLayoutImpact, computed::Outline};
+use crate::{BorderSide, ComputedStyleInvalidationImpact, computed::Outline};
 
 #[test]
 fn computed_style_initial_snapshot_is_total_and_canonical() {
@@ -331,7 +331,7 @@ fn computed_style_accessors_match_property_entries() {
 }
 
 #[test]
-fn computed_style_layout_impact_is_owned_by_computed_style() {
+fn computed_style_invalidation_impact_is_owned_by_computed_style() {
     let base = ComputedStyle::initial();
     let paint_only = base
         .with_property(
@@ -342,14 +342,25 @@ fn computed_style_layout_impact_is_owned_by_computed_style() {
     let layout_affecting = base
         .with_property(PropertyId::Width, length_percentage_or_auto_px(120.0))
         .expect("width update");
+    let paint_order_affecting = base
+        .with_property(
+            PropertyId::ZIndex,
+            ComputedValue::ZIndex(ZIndex::Integer(2)),
+        )
+        .expect("z-index update");
 
     assert_eq!(
-        paint_only.layout_impact_against(&base),
-        ComputedStyleLayoutImpact::PaintOnly
+        paint_only.invalidation_impact_against(&base),
+        ComputedStyleInvalidationImpact::PaintOnly
     );
     assert_eq!(
-        layout_affecting.layout_impact_against(&base),
-        ComputedStyleLayoutImpact::LayoutAffecting
+        layout_affecting.invalidation_impact_against(&base),
+        ComputedStyleInvalidationImpact::LayoutAffecting
+    );
+    assert_eq!(
+        paint_order_affecting.invalidation_impact_against(&base),
+        ComputedStyleInvalidationImpact::LayoutAffecting,
+        "z-index remains conservatively layout-affecting until retained paint-order invalidation is narrower"
     );
 }
 

--- a/crates/css/src/lib.rs
+++ b/crates/css/src/lib.rs
@@ -58,11 +58,11 @@ pub use cascade::{
     try_resolve_document_styles_with_limits,
 };
 pub use computed::{
-    BorderEdges, BorderSide, BoxMetrics, ComputedDocumentStyle, ComputedDocumentStyleLayoutImpact,
-    ComputedDocumentStyleWithStats, ComputedElementStyle, ComputedStyleBuildError,
-    ComputedStyleBuilder, ComputedStyleEntry, ComputedStyleLayoutImpact,
-    ComputedStyleResolutionError, ComputedStyleReuseStats, ComputedValue,
-    ComputedValueDiscriminant, ComputedValueNormalizationError,
+    BorderEdges, BorderSide, BoxMetrics, ComputedDocumentStyle,
+    ComputedDocumentStyleInvalidationImpact, ComputedDocumentStyleWithStats, ComputedElementStyle,
+    ComputedStyleBuildError, ComputedStyleBuilder, ComputedStyleEntry,
+    ComputedStyleInvalidationImpact, ComputedStyleResolutionError, ComputedStyleReuseStats,
+    ComputedValue, ComputedValueDiscriminant, ComputedValueNormalizationError,
     ComputedValueNormalizationErrorKind, IncrementalComputedDocumentStyle, StylePhaseOutput,
     build_style_tree_from_computed_styles, build_style_tree_with_stylesheets,
     compute_document_styles, compute_document_styles_from_resolved_styles,

--- a/crates/css/src/properties/data.rs
+++ b/crates/css/src/properties/data.rs
@@ -14,7 +14,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::TransparentColor,
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -24,7 +24,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::TransparentColor,
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -34,7 +34,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::BorderStyleNone,
             PropertySpecifiedValueKind::BorderStyleKeyword,
             PropertyComputedValueKind::BorderStyleKeyword,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -44,7 +44,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -54,7 +54,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::TransparentColor,
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -64,7 +64,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::BorderStyleNone,
             PropertySpecifiedValueKind::BorderStyleKeyword,
             PropertyComputedValueKind::BorderStyleKeyword,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -74,7 +74,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -84,7 +84,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::TransparentColor,
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -94,7 +94,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::BorderStyleNone,
             PropertySpecifiedValueKind::BorderStyleKeyword,
             PropertyComputedValueKind::BorderStyleKeyword,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -104,7 +104,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -114,7 +114,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::TransparentColor,
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -124,7 +124,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::BorderStyleNone,
             PropertySpecifiedValueKind::BorderStyleKeyword,
             PropertyComputedValueKind::BorderStyleKeyword,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -134,7 +134,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -144,7 +144,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ColorBlack,
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::inherited_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -154,7 +154,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::DisplayInline,
             PropertySpecifiedValueKind::DisplayKeyword,
             PropertyComputedValueKind::DisplayKeyword,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::box_tree_layout_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -164,7 +164,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::FontSizePx16,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::inherited_text_metrics_layout_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -174,7 +174,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::AutoKeyword,
             PropertySpecifiedValueKind::LengthPercentageOrAuto,
             PropertyComputedValueKind::LengthPercentageOrAuto,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -184,7 +184,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         )
         .with_length_sign(PropertyLengthSignPolicy::AllowNegative),
     ),
@@ -195,7 +195,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         )
         .with_length_sign(PropertyLengthSignPolicy::AllowNegative),
     ),
@@ -206,7 +206,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         )
         .with_length_sign(PropertyLengthSignPolicy::AllowNegative),
     ),
@@ -217,7 +217,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         )
         .with_length_sign(PropertyLengthSignPolicy::AllowNegative),
     ),
@@ -228,7 +228,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::NoneKeyword,
             PropertySpecifiedValueKind::LengthPercentageOrNone,
             PropertyComputedValueKind::LengthPercentageOrNone,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -238,7 +238,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::AutoKeyword,
             PropertySpecifiedValueKind::LengthPercentageOrAuto,
             PropertyComputedValueKind::LengthPercentageOrAuto,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -248,7 +248,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::OverflowVisible,
             PropertySpecifiedValueKind::OverflowKeyword,
             PropertyComputedValueKind::OverflowKeyword,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::overflow_clip_layout_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -258,7 +258,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::TransparentColor,
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -268,7 +268,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::OutlineStyleNone,
             PropertySpecifiedValueKind::OutlineStyleKeyword,
             PropertyComputedValueKind::OutlineStyleKeyword,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -278,7 +278,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -288,7 +288,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -298,7 +298,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -308,7 +308,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -318,7 +318,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZeroPx,
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -328,7 +328,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::PositionStatic,
             PropertySpecifiedValueKind::PositionKeyword,
             PropertyComputedValueKind::PositionKeyword,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_paint_order_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -338,7 +338,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::TextDecorationLineNone,
             PropertySpecifiedValueKind::TextDecorationLineKeyword,
             PropertyComputedValueKind::TextDecorationLineKeyword,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
     ),
     PropertyRegistration::new(
@@ -348,7 +348,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::AutoKeyword,
             PropertySpecifiedValueKind::LengthPercentageOrAuto,
             PropertyComputedValueKind::LengthPercentageOrAuto,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
     ),
     PropertyRegistration::new(
@@ -358,7 +358,7 @@ pub(super) const PROPERTY_REGISTRATION_DATA: [PropertyRegistration; 35] = [
             InitialStyleValue::ZIndexAuto,
             PropertySpecifiedValueKind::ZIndex,
             PropertyComputedValueKind::ZIndex,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::conservative_layout_paint_order_paint(),
         ),
     ),
 ];

--- a/crates/css/src/properties/mod.rs
+++ b/crates/css/src/properties/mod.rs
@@ -9,7 +9,7 @@
 //!   values
 //! - property-owned value-range metadata for specified-value validation
 //! - the current-scope invalid-value handling rule
-//! - the current narrow CSS-owned invalidation impact classification
+//! - CSS-owned invalidation impact classification for supported longhands
 //!
 //! `PropertyId` is the stable identity for one supported property.
 //! `PropertyId::metadata()` is the normative source for inheritance,

--- a/crates/css/src/properties/registry.rs
+++ b/crates/css/src/properties/registry.rs
@@ -163,7 +163,7 @@ pub fn property_registry_metadata_debug_snapshot() -> String {
         writeln!(
             &mut output,
             "  invalidation-impact: {}",
-            metadata.invalidation_impact.as_debug_label()
+            metadata.invalidation_impact.to_debug_label()
         )
         .expect("write snapshot");
     }

--- a/crates/css/src/properties/tests.rs
+++ b/crates/css/src/properties/tests.rs
@@ -16,7 +16,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::BorderBottomColor,
@@ -25,7 +25,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::BorderBottomStyle,
@@ -34,7 +34,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::BorderStyleKeyword,
             PropertyComputedValueKind::BorderStyleKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::BorderBottomWidth,
@@ -43,7 +43,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::BorderLeftColor,
@@ -52,7 +52,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::BorderLeftStyle,
@@ -61,7 +61,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::BorderStyleKeyword,
             PropertyComputedValueKind::BorderStyleKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::BorderLeftWidth,
@@ -70,7 +70,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::BorderRightColor,
@@ -79,7 +79,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::BorderRightStyle,
@@ -88,7 +88,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::BorderStyleKeyword,
             PropertyComputedValueKind::BorderStyleKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::BorderRightWidth,
@@ -97,7 +97,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::BorderTopColor,
@@ -106,7 +106,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::BorderTopStyle,
@@ -115,7 +115,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::BorderStyleKeyword,
             PropertyComputedValueKind::BorderStyleKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::BorderTopWidth,
@@ -124,7 +124,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::Color,
@@ -133,7 +133,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::inherited_paint(),
         ),
         (
             PropertyId::Display,
@@ -142,7 +142,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::DisplayKeyword,
             PropertyComputedValueKind::DisplayKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::box_tree_layout_paint(),
         ),
         (
             PropertyId::FontSize,
@@ -151,7 +151,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::inherited_text_metrics_layout_paint(),
         ),
         (
             PropertyId::Height,
@@ -160,7 +160,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::LengthPercentageOrAuto,
             PropertyComputedValueKind::LengthPercentageOrAuto,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::MarginBottom,
@@ -169,7 +169,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::AllowNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::MarginLeft,
@@ -178,7 +178,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::AllowNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::MarginRight,
@@ -187,7 +187,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::AllowNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::MarginTop,
@@ -196,7 +196,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::AllowNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::MaxWidth,
@@ -205,7 +205,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::LengthPercentageOrNone,
             PropertyComputedValueKind::LengthPercentageOrNone,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::MinWidth,
@@ -214,7 +214,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::LengthPercentageOrAuto,
             PropertyComputedValueKind::LengthPercentageOrAuto,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::Overflow,
@@ -223,7 +223,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::OverflowKeyword,
             PropertyComputedValueKind::OverflowKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::overflow_clip_layout_paint(),
         ),
         (
             PropertyId::OutlineColor,
@@ -232,7 +232,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::Color,
             PropertyComputedValueKind::AbsoluteColor,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::OutlineStyle,
@@ -241,7 +241,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::OutlineStyleKeyword,
             PropertyComputedValueKind::OutlineStyleKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::OutlineWidth,
@@ -250,7 +250,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::PaddingBottom,
@@ -259,7 +259,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::PaddingLeft,
@@ -268,7 +268,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::PaddingRight,
@@ -277,7 +277,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::PaddingTop,
@@ -286,7 +286,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::AbsoluteLength,
             PropertyComputedValueKind::AbsoluteLength,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::Position,
@@ -295,7 +295,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::PositionKeyword,
             PropertyComputedValueKind::PositionKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_paint_order_paint(),
         ),
         (
             PropertyId::TextDecorationLine,
@@ -304,7 +304,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::TextDecorationLineKeyword,
             PropertyComputedValueKind::TextDecorationLineKeyword,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
         ),
         (
             PropertyId::Width,
@@ -313,7 +313,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::LengthPercentageOrAuto,
             PropertyComputedValueKind::LengthPercentageOrAuto,
             PropertyLengthSignPolicy::NonNegative,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
         ),
         (
             PropertyId::ZIndex,
@@ -322,7 +322,7 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
             PropertySpecifiedValueKind::ZIndex,
             PropertyComputedValueKind::ZIndex,
             PropertyLengthSignPolicy::NotLength,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::conservative_layout_paint_order_paint(),
         ),
     ];
 
@@ -427,19 +427,18 @@ fn property_registry_lookup_is_deterministic_for_representative_property_names()
 
 #[test]
 fn property_registry_invalidation_impact_is_explicit_for_every_supported_longhand() {
-    let repaint_only = [
+    let paint_only = [
         PropertyId::BackgroundColor,
         PropertyId::BorderBottomColor,
         PropertyId::BorderLeftColor,
         PropertyId::BorderRightColor,
         PropertyId::BorderTopColor,
-        PropertyId::Color,
         PropertyId::OutlineColor,
         PropertyId::OutlineStyle,
         PropertyId::OutlineWidth,
         PropertyId::TextDecorationLine,
     ];
-    let relayout_and_repaint = [
+    let layout_and_paint = [
         PropertyId::BorderBottomStyle,
         PropertyId::BorderBottomWidth,
         PropertyId::BorderLeftStyle,
@@ -448,8 +447,6 @@ fn property_registry_invalidation_impact_is_explicit_for_every_supported_longhan
         PropertyId::BorderRightWidth,
         PropertyId::BorderTopStyle,
         PropertyId::BorderTopWidth,
-        PropertyId::Display,
-        PropertyId::FontSize,
         PropertyId::Height,
         PropertyId::MarginBottom,
         PropertyId::MarginLeft,
@@ -457,38 +454,70 @@ fn property_registry_invalidation_impact_is_explicit_for_every_supported_longhan
         PropertyId::MarginTop,
         PropertyId::MaxWidth,
         PropertyId::MinWidth,
-        PropertyId::Overflow,
         PropertyId::PaddingBottom,
         PropertyId::PaddingLeft,
         PropertyId::PaddingRight,
         PropertyId::PaddingTop,
-        PropertyId::Position,
         PropertyId::Width,
-        PropertyId::ZIndex,
     ];
 
     assert_eq!(
-        repaint_only.len() + relayout_and_repaint.len(),
+        paint_only.len() + 1 + layout_and_paint.len() + 1 + 1 + 1 + 1 + 1,
         property_registry().entries().len()
     );
 
-    for property in repaint_only {
+    for property in paint_only {
         assert_eq!(
             property.metadata().invalidation_impact,
-            PropertyInvalidationImpact::RepaintOnly,
+            PropertyInvalidationImpact::paint_only(),
             "{}",
             property.name()
         );
     }
 
-    for property in relayout_and_repaint {
+    assert_eq!(
+        PropertyId::Color.metadata().invalidation_impact,
+        PropertyInvalidationImpact::inherited_paint()
+    );
+    assert_eq!(
+        PropertyId::Display.metadata().invalidation_impact,
+        PropertyInvalidationImpact::box_tree_layout_paint()
+    );
+    assert_eq!(
+        PropertyId::FontSize.metadata().invalidation_impact,
+        PropertyInvalidationImpact::inherited_text_metrics_layout_paint()
+    );
+    assert_eq!(
+        PropertyId::Overflow.metadata().invalidation_impact,
+        PropertyInvalidationImpact::overflow_clip_layout_paint()
+    );
+    assert_eq!(
+        PropertyId::Position.metadata().invalidation_impact,
+        PropertyInvalidationImpact::layout_paint_order_paint()
+    );
+    assert_eq!(
+        PropertyId::ZIndex.metadata().invalidation_impact,
+        PropertyInvalidationImpact::conservative_layout_paint_order_paint()
+    );
+
+    for property in layout_and_paint {
         assert_eq!(
             property.metadata().invalidation_impact,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
+            PropertyInvalidationImpact::layout_and_paint(),
             "{}",
             property.name()
         );
     }
+}
+
+#[test]
+fn future_compositor_impact_is_metadata_only_for_current_runtime() {
+    let impact = PropertyInvalidationImpact::future_compositor_metadata();
+
+    assert!(impact.affects_future_compositor());
+    assert!(!impact.requires_runtime_layout());
+    assert!(!impact.requires_runtime_paint());
+    assert_eq!(impact.to_debug_label(), "future-compositor");
 }
 
 #[test]
@@ -556,35 +585,53 @@ fn property_value_boundary_snapshot_is_deterministic() {
 }
 
 #[test]
-fn property_registry_classifies_representative_paint_and_layout_impact() {
+fn property_registry_classifies_representative_ad7_impact_flags() {
     for property in [
-        PropertyId::Color,
         PropertyId::BackgroundColor,
         PropertyId::OutlineWidth,
         PropertyId::TextDecorationLine,
     ] {
-        assert_eq!(
-            property.metadata().invalidation_impact,
-            PropertyInvalidationImpact::RepaintOnly,
-            "{}",
-            property.name()
-        );
+        let impact = property.metadata().invalidation_impact;
+        assert!(impact.affects_paint(), "{}", property.name());
+        assert!(!impact.requires_runtime_layout(), "{}", property.name());
+        assert!(!impact.is_conservative(), "{}", property.name());
     }
 
+    let color = PropertyId::Color.metadata().invalidation_impact;
+    assert!(color.affects_inherited_style());
+    assert!(color.affects_paint());
+    assert!(!color.requires_runtime_layout());
+
+    let display = PropertyId::Display.metadata().invalidation_impact;
+    assert!(display.affects_box_tree());
+    assert!(display.requires_runtime_layout());
+    assert!(display.requires_runtime_paint());
+
+    let font_size = PropertyId::FontSize.metadata().invalidation_impact;
+    assert!(font_size.affects_inherited_style());
+    assert!(font_size.affects_text_metrics());
+    assert!(font_size.requires_runtime_layout());
+
+    let overflow = PropertyId::Overflow.metadata().invalidation_impact;
+    assert!(overflow.affects_overflow_clip());
+    assert!(overflow.requires_runtime_layout());
+    assert!(overflow.requires_runtime_paint());
+
+    let z_index = PropertyId::ZIndex.metadata().invalidation_impact;
+    assert!(z_index.affects_paint_order());
+    assert!(z_index.requires_runtime_layout());
+    assert!(z_index.requires_runtime_paint());
+    assert!(z_index.is_conservative());
+
     for property in [
-        PropertyId::Display,
-        PropertyId::FontSize,
         PropertyId::Width,
         PropertyId::PaddingLeft,
         PropertyId::BorderTopWidth,
-        PropertyId::Overflow,
     ] {
-        assert_eq!(
-            property.metadata().invalidation_impact,
-            PropertyInvalidationImpact::RelayoutAndRepaint,
-            "{}",
-            property.name()
-        );
+        let impact = property.metadata().invalidation_impact;
+        assert!(impact.affects_layout(), "{}", property.name());
+        assert!(impact.affects_paint(), "{}", property.name());
+        assert!(!impact.affects_box_tree(), "{}", property.name());
     }
 }
 

--- a/crates/css/src/properties/types.rs
+++ b/crates/css/src/properties/types.rs
@@ -361,23 +361,162 @@ impl PropertyLengthSignPolicy {
     }
 }
 
-/// Current narrow CSS-owned invalidation impact for one supported longhand.
+/// CSS-owned invalidation impact flags for one supported longhand.
 ///
-/// This is intentionally smaller than the future AD7 taxonomy. The registry
-/// must classify every supported longhand explicitly so incomplete impact
-/// modeling cannot hide behind a constructor default.
+/// AD7 keeps property invalidation semantics in the CSS property registry.
+/// The flags are composable positive CSS facts because one property can affect
+/// multiple engine concerns at once, such as inherited style, text metrics,
+/// layout, paint order, and overflow clipping. Browser/runtime consumes only a
+/// derived CSS-owned runtime projection; it must not inspect these flags to
+/// define CSS property meaning.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PropertyInvalidationImpact {
-    RepaintOnly,
-    RelayoutAndRepaint,
+pub struct PropertyInvalidationImpact {
+    flags: u16,
+    conservative: bool,
 }
 
 impl PropertyInvalidationImpact {
-    pub fn as_debug_label(self) -> &'static str {
-        match self {
-            Self::RepaintOnly => "repaint-only",
-            Self::RelayoutAndRepaint => "relayout-and-repaint",
+    const INHERITED_STYLE: u16 = 1 << 0;
+    const BOX_TREE: u16 = 1 << 1;
+    const LAYOUT: u16 = 1 << 2;
+    const TEXT_METRICS: u16 = 1 << 3;
+    const PAINT: u16 = 1 << 4;
+    const PAINT_ORDER: u16 = 1 << 5;
+    const OVERFLOW_CLIP: u16 = 1 << 6;
+    const FUTURE_COMPOSITOR: u16 = 1 << 7;
+
+    const fn new(flags: u16, conservative: bool) -> Self {
+        Self {
+            flags,
+            conservative,
         }
+    }
+
+    pub const fn paint_only() -> Self {
+        Self::new(Self::PAINT, false)
+    }
+
+    pub const fn inherited_paint() -> Self {
+        Self::new(Self::INHERITED_STYLE | Self::PAINT, false)
+    }
+
+    pub const fn layout_and_paint() -> Self {
+        Self::new(Self::LAYOUT | Self::PAINT, false)
+    }
+
+    pub const fn box_tree_layout_paint() -> Self {
+        Self::new(Self::BOX_TREE | Self::LAYOUT | Self::PAINT, false)
+    }
+
+    pub const fn inherited_text_metrics_layout_paint() -> Self {
+        Self::new(
+            Self::INHERITED_STYLE | Self::TEXT_METRICS | Self::LAYOUT | Self::PAINT,
+            false,
+        )
+    }
+
+    pub const fn overflow_clip_layout_paint() -> Self {
+        Self::new(Self::OVERFLOW_CLIP | Self::LAYOUT | Self::PAINT, false)
+    }
+
+    pub const fn layout_paint_order_paint() -> Self {
+        Self::new(Self::LAYOUT | Self::PAINT_ORDER | Self::PAINT, false)
+    }
+
+    pub const fn conservative_layout_paint_order_paint() -> Self {
+        Self::new(Self::LAYOUT | Self::PAINT_ORDER | Self::PAINT, true)
+    }
+
+    pub const fn future_compositor_metadata() -> Self {
+        Self::new(Self::FUTURE_COMPOSITOR, false)
+    }
+
+    pub const fn is_conservative(self) -> bool {
+        self.conservative
+    }
+
+    pub const fn affects_inherited_style(self) -> bool {
+        self.has_flag(Self::INHERITED_STYLE)
+    }
+
+    pub const fn affects_box_tree(self) -> bool {
+        self.has_flag(Self::BOX_TREE)
+    }
+
+    pub const fn affects_layout(self) -> bool {
+        self.has_flag(Self::LAYOUT)
+    }
+
+    pub const fn affects_text_metrics(self) -> bool {
+        self.has_flag(Self::TEXT_METRICS)
+    }
+
+    pub const fn affects_paint(self) -> bool {
+        self.has_flag(Self::PAINT)
+    }
+
+    pub const fn affects_paint_order(self) -> bool {
+        self.has_flag(Self::PAINT_ORDER)
+    }
+
+    pub const fn affects_overflow_clip(self) -> bool {
+        self.has_flag(Self::OVERFLOW_CLIP)
+    }
+
+    pub const fn affects_future_compositor(self) -> bool {
+        self.has_flag(Self::FUTURE_COMPOSITOR)
+    }
+
+    pub const fn requires_runtime_layout(self) -> bool {
+        self.affects_box_tree()
+            || self.affects_layout()
+            || self.affects_text_metrics()
+            || self.affects_overflow_clip()
+    }
+
+    pub const fn requires_runtime_paint(self) -> bool {
+        self.affects_paint() || self.affects_paint_order() || self.affects_overflow_clip()
+    }
+
+    pub fn to_debug_label(self) -> String {
+        let mut labels = Vec::new();
+        if self.affects_inherited_style() {
+            labels.push("inherited-style");
+        }
+        if self.affects_box_tree() {
+            labels.push("box-tree");
+        }
+        if self.affects_layout() {
+            labels.push("layout");
+        }
+        if self.affects_text_metrics() {
+            labels.push("text-metrics");
+        }
+        if self.affects_paint() {
+            labels.push("paint");
+        }
+        if self.affects_paint_order() {
+            labels.push("paint-order");
+        }
+        if self.affects_overflow_clip() {
+            labels.push("overflow-clip");
+        }
+        if self.affects_future_compositor() {
+            labels.push("future-compositor");
+        }
+
+        let mut label = labels.join("+");
+        if self.conservative {
+            if !label.is_empty() {
+                label.push('+');
+            }
+            label.push_str("conservative");
+        }
+        label
+    }
+
+    const fn has_flag(self, flag: u16) -> bool {
+        self.flags & flag != 0
     }
 }
 

--- a/crates/css/tests/fixtures/properties/registry_metadata.snap
+++ b/crates/css/tests/fixtures/properties/registry_metadata.snap
@@ -8,7 +8,7 @@ property[0]: background-color
   computed-value: absolute-color
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[1]: border-bottom-color
   inheritance: not-inherited
   initial: transparent
@@ -16,7 +16,7 @@ property[1]: border-bottom-color
   computed-value: absolute-color
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[2]: border-bottom-style
   inheritance: not-inherited
   initial: none
@@ -24,7 +24,7 @@ property[2]: border-bottom-style
   computed-value: border-style-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[3]: border-bottom-width
   inheritance: not-inherited
   initial: 0px
@@ -32,7 +32,7 @@ property[3]: border-bottom-width
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[4]: border-left-color
   inheritance: not-inherited
   initial: transparent
@@ -40,7 +40,7 @@ property[4]: border-left-color
   computed-value: absolute-color
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[5]: border-left-style
   inheritance: not-inherited
   initial: none
@@ -48,7 +48,7 @@ property[5]: border-left-style
   computed-value: border-style-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[6]: border-left-width
   inheritance: not-inherited
   initial: 0px
@@ -56,7 +56,7 @@ property[6]: border-left-width
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[7]: border-right-color
   inheritance: not-inherited
   initial: transparent
@@ -64,7 +64,7 @@ property[7]: border-right-color
   computed-value: absolute-color
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[8]: border-right-style
   inheritance: not-inherited
   initial: none
@@ -72,7 +72,7 @@ property[8]: border-right-style
   computed-value: border-style-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[9]: border-right-width
   inheritance: not-inherited
   initial: 0px
@@ -80,7 +80,7 @@ property[9]: border-right-width
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[10]: border-top-color
   inheritance: not-inherited
   initial: transparent
@@ -88,7 +88,7 @@ property[10]: border-top-color
   computed-value: absolute-color
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[11]: border-top-style
   inheritance: not-inherited
   initial: none
@@ -96,7 +96,7 @@ property[11]: border-top-style
   computed-value: border-style-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[12]: border-top-width
   inheritance: not-inherited
   initial: 0px
@@ -104,7 +104,7 @@ property[12]: border-top-width
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[13]: color
   inheritance: inherited
   initial: black
@@ -112,7 +112,7 @@ property[13]: color
   computed-value: absolute-color
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: inherited-style+paint
 property[14]: display
   inheritance: not-inherited
   initial: inline
@@ -120,7 +120,7 @@ property[14]: display
   computed-value: display-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: box-tree+layout+paint
 property[15]: font-size
   inheritance: inherited
   initial: 16px
@@ -128,7 +128,7 @@ property[15]: font-size
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: inherited-style+layout+text-metrics+paint
 property[16]: height
   inheritance: not-inherited
   initial: auto
@@ -136,7 +136,7 @@ property[16]: height
   computed-value: length-percentage-or-auto
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[17]: margin-bottom
   inheritance: not-inherited
   initial: 0px
@@ -144,7 +144,7 @@ property[17]: margin-bottom
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: allow-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[18]: margin-left
   inheritance: not-inherited
   initial: 0px
@@ -152,7 +152,7 @@ property[18]: margin-left
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: allow-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[19]: margin-right
   inheritance: not-inherited
   initial: 0px
@@ -160,7 +160,7 @@ property[19]: margin-right
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: allow-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[20]: margin-top
   inheritance: not-inherited
   initial: 0px
@@ -168,7 +168,7 @@ property[20]: margin-top
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: allow-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[21]: max-width
   inheritance: not-inherited
   initial: none
@@ -176,7 +176,7 @@ property[21]: max-width
   computed-value: length-percentage-or-none
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[22]: min-width
   inheritance: not-inherited
   initial: auto
@@ -184,7 +184,7 @@ property[22]: min-width
   computed-value: length-percentage-or-auto
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[23]: overflow
   inheritance: not-inherited
   initial: visible
@@ -192,7 +192,7 @@ property[23]: overflow
   computed-value: overflow-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint+overflow-clip
 property[24]: outline-color
   inheritance: not-inherited
   initial: transparent
@@ -200,7 +200,7 @@ property[24]: outline-color
   computed-value: absolute-color
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[25]: outline-style
   inheritance: not-inherited
   initial: none
@@ -208,7 +208,7 @@ property[25]: outline-style
   computed-value: outline-style-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[26]: outline-width
   inheritance: not-inherited
   initial: 0px
@@ -216,7 +216,7 @@ property[26]: outline-width
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[27]: padding-bottom
   inheritance: not-inherited
   initial: 0px
@@ -224,7 +224,7 @@ property[27]: padding-bottom
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[28]: padding-left
   inheritance: not-inherited
   initial: 0px
@@ -232,7 +232,7 @@ property[28]: padding-left
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[29]: padding-right
   inheritance: not-inherited
   initial: 0px
@@ -240,7 +240,7 @@ property[29]: padding-right
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[30]: padding-top
   inheritance: not-inherited
   initial: 0px
@@ -248,7 +248,7 @@ property[30]: padding-top
   computed-value: absolute-length
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[31]: position
   inheritance: not-inherited
   initial: static
@@ -256,7 +256,7 @@ property[31]: position
   computed-value: position-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint+paint-order
 property[32]: text-decoration-line
   inheritance: not-inherited
   initial: none
@@ -264,7 +264,7 @@ property[32]: text-decoration-line
   computed-value: text-decoration-line-keyword
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: repaint-only
+  invalidation-impact: paint
 property[33]: width
   inheritance: not-inherited
   initial: auto
@@ -272,7 +272,7 @@ property[33]: width
   computed-value: length-percentage-or-auto
   invalid-value-policy: reject-declaration
   length-sign: non-negative
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint
 property[34]: z-index
   inheritance: not-inherited
   initial: auto
@@ -280,4 +280,4 @@ property[34]: z-index
   computed-value: z-index
   invalid-value-policy: reject-declaration
   length-sign: not-length
-  invalidation-impact: relayout-and-repaint
+  invalidation-impact: layout+paint+paint-order+conservative

--- a/docs/css/ad1-css-value-property-ownership-architecture.md
+++ b/docs/css/ad1-css-value-property-ownership-architecture.md
@@ -104,7 +104,7 @@ The CSS subsystem is layered, but the semantic ownership stays inside CSS:
      `ComputedStyle`, `ComputedDocumentStyle`, and `StyledNode` construction;
    - exposes the typed runtime handoff consumed by layout, paint, and browser
      orchestration;
-   - currently owns computed-style layout-impact comparison in
+   - owns computed-style invalidation-impact projection in
      `crates/css/src/computed/impact.rs`.
 
 ## Value Lifecycle Terminology
@@ -185,20 +185,16 @@ or duplicated property metadata.
 Current behavior:
 
 - `crates/css/src/computed/impact.rs` contains the current CSS-owned
-  computed-style layout-impact comparison.
+  computed-style invalidation-impact comparison.
 - Browser/runtime consumes the resulting computed-document impact through the
   retained rendering path.
-- This current implementation is acceptable as CSS-owned current behavior for
-  AD1.
+- AD7 defines the richer CSS-owned invalidation impact classification model,
+  including the concrete taxonomy, registry-backed impact metadata, the
+  narrow Browser/runtime consumption API, and the focused CSS and
+  Browser/runtime tests for that behavior.
 
-AD1 does not make `computed/impact.rs` the final AD architecture. AD7 will
-introduce the richer CSS-owned invalidation impact classification model,
-including the concrete taxonomy, registry-backed impact metadata where
-appropriate, the narrow Browser/runtime consumption API, and the focused CSS
-and Browser/runtime tests for that behavior.
-
-Until AD7 lands, contributors must not move CSS property impact classification
-into browser/runtime. If a style change cannot be safely classified through
+Contributors must not move CSS property impact classification into
+browser/runtime. If a style change cannot be safely classified through
 CSS-owned behavior, runtime must use an explicit conservative fallback.
 
 ## Browser/runtime Consumption Boundary
@@ -280,17 +276,17 @@ AD1 implements:
 - explicit CSS/browser/runtime/layout/paint ownership boundaries;
 - terminology for parsed component values, declared values, specified values,
   computed values, and future used/actual values;
-- documentation that current impact comparison remains CSS-owned behavior until
-  AD7;
+- documentation that current impact comparison remains CSS-owned behavior;
 - a feature gap tracker update that records AD1 as architecture-only progress.
 
 AD1 does not implement:
 
 - new supported properties;
-- new typed Rust property impact categories;
-- registry-backed invalidation impact metadata;
-- a Browser/runtime impact API;
-- Browser/runtime integration tests for paint-only style changes;
+- new typed Rust property impact categories beyond the architecture boundary;
+- registry-backed invalidation impact metadata; AD7 implements this separately;
+- a Browser/runtime impact API; AD7 implements this separately;
+- Browser/runtime integration tests for paint-only style changes; AD7 adds
+  these separately;
 - shorthand completeness;
 - CSS-wide keyword parsing;
 - full selectors, full cascade, media queries, custom properties, animations,
@@ -300,7 +296,7 @@ AD1 does not implement:
 ## AD7 Handoff
 
 AD7 is the implementation issue for concrete CSS-owned invalidation impact
-classification. AD7 should define:
+classification. AD7 defines:
 
 - the typed impact taxonomy for supported properties;
 - whether impact is represented directly as registry metadata, derived from
@@ -310,7 +306,9 @@ classification. AD7 should define:
 - Browser/runtime tests proving runtime consumes CSS-owned impact without
   owning property semantics.
 
-AD1 intentionally stops before those choices become Rust APIs.
+AD1 intentionally stops before those choices become Rust APIs. See
+`docs/css/ad7-css-owned-invalidation-impact-classification.md` for the
+implemented contract.
 
 ## Invariants
 

--- a/docs/css/ad4-css-property-registry-longhand-metadata.md
+++ b/docs/css/ad4-css-property-registry-longhand-metadata.md
@@ -26,6 +26,7 @@ Related documents:
 - `docs/css/ad1-css-value-property-ownership-architecture.md`
 - `docs/css/ad2-typed-core-css-value-model.md`
 - `docs/css/ad3-css-wide-keyword-handling.md`
+- `docs/css/ad7-css-owned-invalidation-impact-classification.md`
 - `docs/css/s1-property-system-architecture-computed-style-contract.md`
 - `docs/css/s2-property-identifiers-property-registry.md`
 - `docs/css/s3-parsed-specified-value-representations.md`
@@ -94,47 +95,41 @@ path.
 
 ## Explicit Invalidation Impact
 
-AD4 adds a narrow CSS-owned property impact metadata field:
+AD4 introduced the first narrow CSS-owned property impact metadata field for
+the supported longhand registry. AD7 later replaced that two-category model
+with a composable `PropertyInvalidationImpact` flags struct while preserving
+the same ownership rule: every supported longhand registration must pass an
+explicit impact value, and `PropertyMetadata` constructors do not provide a
+default impact category.
 
-```rust
-pub enum PropertyInvalidationImpact {
-    RepaintOnly,
-    RelayoutAndRepaint,
-}
-```
-
-Every supported longhand registration must pass an explicit impact value.
-`PropertyMetadata` constructors do not provide a default impact category.
 This prevents incomplete property classification from hiding behind a silent
-conservative fallback.
-
-`RepaintOnly` means a computed value change can keep retained layout valid in
-the current supported model and requires paint work. `RelayoutAndRepaint`
-means a computed value change may affect layout inputs or downstream geometry,
-so retained layout must be dirtied conservatively and paint follows layout.
-
-This is not the final invalidation taxonomy. AD7 remains the extension point
-for richer CSS-owned impact categories such as stacking, overflow, text,
-fonts, selector dependencies, containment, compositor-relevant behavior, or
-more precise dirty scopes.
+conservative fallback. The current AD7 taxonomy is documented in
+`docs/css/ad7-css-owned-invalidation-impact-classification.md`.
 
 ## Runtime Consumption Boundary
 
-`crates/css/src/computed/impact.rs` maps registry metadata into the existing
-runtime-facing computed-style impact API:
+`crates/css/src/computed/impact.rs` maps registry metadata into the
+runtime-facing computed-style invalidation API:
 
 ```text
-PropertyInvalidationImpact::RepaintOnly
-  -> ComputedStyleLayoutImpact::PaintOnly
-
-PropertyInvalidationImpact::RelayoutAndRepaint
-  -> ComputedStyleLayoutImpact::LayoutAffecting
+ComputedDocumentStyle::invalidation_impact_against(previous)
 ```
 
-Browser/runtime continues to consume
-`ComputedDocumentStyle::layout_impact_against(...)` through retained rendering
+The runtime-facing projection is intentionally narrow:
+
+- `NoVisualImpact`
+- `StyleOnly`
+- `PaintOnly`
+- `LayoutAffecting`
+- `Unknown`
+
+`NoVisualImpact` and `StyleOnly` are derived projection categories, not raw
+registry metadata flags. Raw `PropertyInvalidationImpact` metadata records
+positive CSS impact facts only.
+
+Browser/runtime consumes this CSS-owned result through retained rendering
 state. Browser/runtime does not inspect declaration names, parse CSS values,
-or maintain a CSS property-impact table.
+inspect registry flags, or maintain a CSS property-impact table.
 
 ## Unknown And Unsupported Properties
 
@@ -213,5 +208,6 @@ AD4 deliberately excludes:
 - custom properties and `var(...)`;
 - animations and transitions;
 - compositor/GPU behavior;
-- full AD7 invalidation taxonomy;
+- full AD7 invalidation taxonomy; AD7 now documents and implements that
+  taxonomy for the current supported longhand subset;
 - public CSSOM metadata APIs.

--- a/docs/css/ad7-css-owned-invalidation-impact-classification.md
+++ b/docs/css/ad7-css-owned-invalidation-impact-classification.md
@@ -1,0 +1,191 @@
+# AD7: CSS-Owned Invalidation Impact Classification
+
+Last updated: 2026-06-29
+Status: implemented contract for Milestone AD issue 7
+
+This document defines Borrowser's CSS-owned invalidation impact classification
+for the current supported longhand property subset.
+
+AD7 replaces AD4's narrow `repaint-only` versus `relayout-and-repaint`
+metadata with composable CSS-owned flags. Browser/runtime may consume a
+narrow computed-style invalidation projection, but it must not infer CSS
+property meaning from property names, declaration text, or a local
+`PropertyId` table.
+
+AD7 does not add new CSS properties, selector dependency invalidation,
+descendant dependency graphs, media/container query invalidation, custom
+properties, animations, compositor layers, GPU behavior, transform/opacity
+support, dirty-region rendering, or broad CSS conformance.
+
+Related code:
+
+- `crates/css/src/properties/types.rs`
+- `crates/css/src/properties/data.rs`
+- `crates/css/src/properties/registry.rs`
+- `crates/css/src/computed/impact.rs`
+- `crates/browser/src/page/style_phase.rs`
+- `crates/browser/src/page/retained_render_state.rs`
+- `crates/browser/src/rendering/tests/runtime_state.rs`
+
+Related documents:
+
+- `docs/css/ad1-css-value-property-ownership-architecture.md`
+- `docs/css/ad4-css-property-registry-longhand-metadata.md`
+- `docs/css/ad5-specified-computed-value-boundaries.md`
+- `docs/css/s9-property-system-computed-style-runtime-contract.md`
+- `docs/rendering/ac3-explicit-dirty-state-tracking.md`
+- `docs/rendering/ac4-deterministic-render-work-plans.md`
+- `docs/rendering/ac10-retained-rendering-runtime-closeout.md`
+- `docs/engine-feature-gap-tracker.md`
+
+## Ownership
+
+CSS owns:
+
+- the invalidation impact flags attached to supported longhand metadata;
+- the conservative classification for each supported property;
+- comparison of computed styles;
+- projection from property impact flags to the narrow runtime-facing
+  invalidation result.
+
+Browser/runtime owns:
+
+- retained dirty-state lifetime;
+- retained style/layout/paint generation counters;
+- render work planning;
+- conservative fallback when CSS reports unknown document shape or
+  layout-affecting impact.
+
+Browser/runtime may consume only the CSS-owned computed-document impact result:
+
+```text
+ComputedDocumentStyle::invalidation_impact_against(previous)
+```
+
+Browser/runtime must not inspect `PropertyId`, property names, registry flags,
+authored CSS, or computed values to define CSS property impact.
+
+## Impact Flags
+
+`PropertyInvalidationImpact` is a composable flags struct. Raw registry
+metadata contains only positive CSS impact facts. Projection results such as
+`NoVisualImpact` and `StyleOnly` are derived by the computed-style comparison
+layer, not stored as raw longhand metadata flags. Flags are serialized in
+deterministic canonical order in the registry metadata debug snapshot.
+
+| flag | meaning | owner | consumers | intentionally not implemented |
+| --- | --- | --- | --- | --- |
+| `inherited-style` | the property participates in inherited computed-style propagation | CSS | CSS classification and computed comparison | full descendant invalidation/dependency graphs |
+| `box-tree` | the property can change generated box-tree structure or display participation | CSS | runtime projection as layout-affecting | targeted box-tree invalidation |
+| `layout` | the property can affect layout inputs, geometry, or retained layout validity | CSS | runtime projection as layout-affecting | subtree/minimal relayout execution |
+| `text-metrics` | the property can affect text measurement or line layout | CSS | runtime projection as layout-affecting | full font system or advanced line layout |
+| `paint` | the property can affect paint primitives or visual output | CSS | runtime projection as paint work | dirty-region rendering |
+| `paint-order` | the property can affect stacking or paint ordering | CSS | runtime projection as paint work; conservative layout when still required | retained paint-order dependency invalidation |
+| `overflow-clip` | the property can affect overflow policy, clipping, or related layout/paint inputs | CSS | runtime projection as layout-affecting | overflow-x/y split, scroll offsets, scrollbars, viewport/body propagation |
+| `future-compositor` | metadata hook for future compositor-relevant properties | CSS | none in current runtime | compositor, GPU, transforms, opacity, animations |
+
+The `conservative` marker is not a separate engine feature. It records that the
+classification intentionally widens current runtime work because the engine
+does not yet have narrower safe retained dependency data.
+
+## Supported Longhand Classification
+
+AD7 classifies only currently supported longhands:
+
+| longhands | impact |
+| --- | --- |
+| `background-color`, border color longhands, outline longhands, `text-decoration-line` | `paint` |
+| `color` | `inherited-style+paint` |
+| border style and width longhands, `height`, margin longhands, `max-width`, `min-width`, padding longhands, `width` | `layout+paint` |
+| `display` | `box-tree+layout+paint` |
+| `font-size` | `inherited-style+layout+text-metrics+paint` |
+| `overflow` | `layout+paint+overflow-clip` |
+| `position` | `layout+paint+paint-order` |
+| `z-index` | `layout+paint+paint-order+conservative` |
+
+`z-index` remains conservatively layout-affecting in the runtime projection.
+The property is paint-order relevant, but current retained runtime contracts do
+not yet provide a narrower paint-order invalidation path that can safely skip
+layout in every supported case.
+
+## Runtime Projection
+
+`crates/css/src/computed/impact.rs` compares computed styles in canonical
+property order and projects changed property flags into:
+
+| projection | meaning | source |
+| --- | --- | --- |
+| `NoVisualImpact` | no changed property has current downstream runtime-relevant impact | derived from absence of positive runtime impact |
+| `StyleOnly` | a changed property affects CSS style state but not current runtime layout or paint work | derived from positive CSS metadata such as `inherited-style` when it is not paired with layout or paint impact; no current supported longhand projects this way |
+| `PaintOnly` | changed properties require paint work but not layout work | derived from positive paint-related metadata without runtime layout impact |
+| `LayoutAffecting` | changed properties require layout work, and paint dirtiness cascades from layout | derived from positive layout, box-tree, text-metrics, or overflow/clip metadata |
+| `Unknown` | CSS cannot compare the document styles safely | derived from document-shape mismatch |
+
+`Unknown` is reserved for document-shape mismatches, such as different element
+counts or selector element identities. Browser/runtime treats
+`LayoutAffecting` and `Unknown` conservatively.
+
+For paint-only style changes, Browser/runtime may remove style-derived layout
+dirty entries and mark paint dirty through `PaintOnlyStyleChanged`. Existing
+unrelated layout dirtiness, such as viewport dirtiness, is preserved.
+
+For derived no-visual or style-only changes, Browser/runtime may remove
+style-derived layout and paint cascades. AD7 does not currently classify any
+supported longhand this way.
+
+## Debug And Test Surface
+
+`property_registry_metadata_debug_snapshot()` emits the canonical impact flags
+for every supported longhand. The fixture
+`crates/css/tests/fixtures/properties/registry_metadata.snap` is an internal
+regression contract, not CSSOM.
+
+Targeted CSS tests verify:
+
+- every supported longhand has explicit impact metadata;
+- representative flags such as inherited style, box tree, text metrics,
+  overflow clip, paint order, and conservative impact are present;
+- computed-style comparison projects property flags deterministically;
+- unknown document shape stays conservative.
+
+Browser/runtime tests verify:
+
+- paint-only CSS-owned impact can avoid relayout through the real retained
+  style recomputation path;
+- unrelated layout dirtiness is preserved when a paint-only style change is
+  narrowed;
+- paint-order changes such as `z-index` remain conservatively layout-affecting
+  until narrower retained paint-order invalidation exists.
+
+## Invariants
+
+- CSS remains the sole owner of property invalidation semantics.
+- The supported longhand registry is the canonical metadata source.
+- Every supported longhand has explicit invalidation impact metadata.
+- Impact flag debug labels are deterministic.
+- Browser/runtime consumes only the CSS-owned computed-document projection.
+- Browser/runtime does not maintain a CSS property-impact table.
+- Conservative classifications are visible and documented.
+- Unsupported properties remain unsupported and are not added as placeholders.
+
+## Deliberate Exclusions
+
+AD7 deliberately excludes:
+
+- new supported CSS properties;
+- full known-property modeling for unsupported CSS;
+- selector dependency invalidation;
+- descendant dependency graphs;
+- media or container query invalidation;
+- custom properties and `var(...)`;
+- animations and transitions;
+- transforms, opacity, filters, and compositor/GPU behavior;
+- dirty-region rendering;
+- targeted relayout;
+- retained paint-order dependency graphs;
+- broad CSS conformance work.
+
+Future property work should classify impact when a supported longhand enters
+the registry. If a property's exact impact is not yet proven by layout, paint,
+and runtime contracts, the classification must remain conservative and explain
+why.

--- a/docs/css/s9-property-system-computed-style-runtime-contract.md
+++ b/docs/css/s9-property-system-computed-style-runtime-contract.md
@@ -214,8 +214,8 @@ Layout may:
 - perform layout-dependent geometry decisions from already-computed values
 - define layout-specific algorithms for block, inline, replaced, and text
   behavior
-- consume CSS-owned computed-style layout-impact classification when deciding
-  whether style changes affect layout
+- consume CSS-owned computed-style invalidation-impact classification when
+  deciding whether style changes affect layout or paint
 
 Layout must not:
 
@@ -238,23 +238,38 @@ Paint and `gfx` must not:
 - recover from invalid declarations
 - mutate `ComputedStyle`
 
-## Layout-Impact Classification
+## Invalidation-Impact Classification
 
-AC6 adds CSS-owned computed-style layout-impact classification:
+AC6 added the first CSS-owned computed-style layout-impact comparison. AD7
+extends that into a CSS-owned invalidation-impact projection:
 
-- `ComputedStyle::layout_impact_against(...)`
-- `ComputedDocumentStyle::layout_impact_against(...)`
+- `ComputedStyle::invalidation_impact_against(...)`
+- `ComputedDocumentStyle::invalidation_impact_against(...)`
 
 The classifier compares computed-style outputs and returns a conservative
-impact result for the currently supported property subset. Paint-only
-properties such as color, background color, outline, and text decoration may
-preserve retained layout. Display, font metrics, box metrics, sizing,
-positioning, overflow, z-index, and unknown document-shape changes are
-layout-affecting or unknown and must conservatively dirty layout.
+runtime-facing result for the currently supported property subset:
+
+- `NoVisualImpact`
+- `StyleOnly`
+- `PaintOnly`
+- `LayoutAffecting`
+- `Unknown`
+
+`NoVisualImpact` and `StyleOnly` are derived runtime-facing results. They are
+not stored as raw supported-longhand registry flags. Raw property metadata
+records positive CSS impact facts, and the computed-style classifier derives
+the narrow runtime category from those facts.
+
+Paint-only properties such as background color, outline, text decoration, and
+inherited `color` may preserve retained layout. Display, text metrics, box
+metrics, sizing, positioning, overflow, conservative paint-order impact such
+as `z-index`, and unknown document-shape changes are layout-affecting or
+unknown and must conservatively dirty layout.
 
 Browser/runtime may consume the classification result to decide retained
-layout reuse. Browser/runtime must not duplicate the property table or infer
-CSS property impact by inspecting declarations.
+layout reuse and paint dirtiness. Browser/runtime must not duplicate the
+property table, inspect registry flags, or infer CSS property impact by
+inspecting declarations.
 
 ## Legacy Compatibility Boundary
 

--- a/docs/engine-feature-gap-tracker.md
+++ b/docs/engine-feature-gap-tracker.md
@@ -66,10 +66,9 @@ Architecture status:
   but unsupported until cascade origin/layer support exists.
 - AD4 formalizes the CSS-owned supported longhand registry and metadata model;
   see `docs/css/ad4-css-property-registry-longhand-metadata.md`. Supported
-  longhands now expose explicit registry metadata, deterministic metadata
-  debug output, and a narrow CSS-owned impact hook for `repaint-only` versus
-  `relayout-and-repaint`. AD4 does not add broad property coverage,
-  shorthand support, or the full AD7 invalidation taxonomy.
+  longhands now expose explicit registry metadata and deterministic metadata
+  debug output. AD4 does not add broad property coverage, shorthand support,
+  or the full AD7 invalidation taxonomy.
 - AD5 defines the specified-value and computed-value boundaries for every
   currently supported longhand; see
   `docs/css/ad5-specified-computed-value-boundaries.md`. The boundary
@@ -84,8 +83,11 @@ Architecture status:
   through the existing longhand registry, specified-value parser, CSS-wide
   keyword handling, computed-value normalization, and invalidation metadata.
   Broad shorthand coverage remains missing.
-- Richer CSS-owned invalidation impact classification beyond the current
-  narrow longhand hook remains future AD7 work.
+- AD7 replaces the old two-bucket longhand impact hook with CSS-owned
+  composable invalidation impact flags for currently supported longhands; see
+  `docs/css/ad7-css-owned-invalidation-impact-classification.md`.
+  Browser/runtime consumes a narrow CSS-owned projection for retained dirty
+  state and work planning without owning CSS property semantics.
 
 - borders:
   - full `border` shorthand support


### PR DESCRIPTION
Resolves #1064 