### PR TITLE
AD7 [follow-up]: harden supported longhand impact coverage

### DIFF
--- a/crates/css/src/properties/tests.rs
+++ b/crates/css/src/properties/tests.rs
@@ -5,6 +5,28 @@ use super::{
     data::PROPERTY_LOOKUP_BY_NAME, property_registry, property_value_boundaries,
     property_value_boundary_debug_snapshot, shorthand_registry,
 };
+use std::collections::BTreeSet;
+
+fn assert_explicit_invalidation_impact(property: PropertyId) {
+    let impact = property.metadata().invalidation_impact;
+    assert!(
+        impact.affects_inherited_style()
+            || impact.affects_box_tree()
+            || impact.affects_layout()
+            || impact.affects_text_metrics()
+            || impact.affects_paint()
+            || impact.affects_paint_order()
+            || impact.affects_overflow_clip()
+            || impact.affects_future_compositor(),
+        "{} must expose explicit invalidation impact metadata",
+        property.name()
+    );
+    assert!(
+        !impact.to_debug_label().is_empty(),
+        "{} must expose a deterministic invalidation impact debug label",
+        property.name()
+    );
+}
 
 #[test]
 fn property_registry_entries_are_total_canonical_and_metadata_backed() {
@@ -384,6 +406,66 @@ fn property_registry_entries_are_total_canonical_and_metadata_backed() {
 }
 
 #[test]
+fn supported_longhand_source_of_truth_is_registry_lookup_and_metadata_backed() {
+    let registry = property_registry();
+    let supported_ids = PropertyId::ALL.into_iter().collect::<BTreeSet<_>>();
+
+    assert_eq!(registry.entries().len(), supported_ids.len());
+    assert_eq!(PROPERTY_LOOKUP_BY_NAME.len(), supported_ids.len());
+
+    let mut entry_ids = BTreeSet::new();
+    let mut entry_names = BTreeSet::new();
+    for (index, property) in PropertyId::ALL.into_iter().enumerate() {
+        let registration = &registry.entries()[index];
+
+        assert_eq!(registration.id(), property, "registry order drifted");
+        assert_eq!(registration.name(), property.name(), "{}", property.name());
+        assert!(entry_ids.insert(registration.id()), "duplicate property id");
+        assert!(
+            entry_names.insert(registration.name()),
+            "duplicate property name {}",
+            registration.name()
+        );
+        assert_eq!(
+            registry.lookup_id(registration.name()),
+            Some(property),
+            "{} lookup must route through the registry",
+            registration.name()
+        );
+        assert_eq!(
+            PropertyId::from_name(registration.name()),
+            Some(property),
+            "{} must resolve through PropertyId::from_name",
+            registration.name()
+        );
+        assert_eq!(
+            registration.metadata(),
+            property.metadata(),
+            "{} must use registry-backed metadata",
+            property.name()
+        );
+        assert_explicit_invalidation_impact(property);
+    }
+
+    assert_eq!(entry_ids, supported_ids);
+    assert_eq!(entry_names.len(), supported_ids.len());
+
+    for lookup in PROPERTY_LOOKUP_BY_NAME {
+        assert!(
+            supported_ids.contains(&lookup.id),
+            "{} lookup must point to a supported longhand",
+            lookup.name
+        );
+        assert_eq!(
+            registry.get(lookup.id).name(),
+            lookup.name,
+            "{} lookup must agree with the registry registration",
+            lookup.name
+        );
+    }
+}
+
+#[test]
 fn property_registry_lookup_is_deterministic_for_representative_property_names() {
     let registry = property_registry();
 
@@ -467,6 +549,7 @@ fn property_registry_invalidation_impact_is_explicit_for_every_supported_longhan
     );
 
     for property in paint_only {
+        assert_explicit_invalidation_impact(property);
         assert_eq!(
             property.metadata().invalidation_impact,
             PropertyInvalidationImpact::paint_only(),
@@ -500,7 +583,15 @@ fn property_registry_invalidation_impact_is_explicit_for_every_supported_longhan
         PropertyInvalidationImpact::conservative_layout_paint_order_paint()
     );
 
+    assert_explicit_invalidation_impact(PropertyId::Color);
+    assert_explicit_invalidation_impact(PropertyId::Display);
+    assert_explicit_invalidation_impact(PropertyId::FontSize);
+    assert_explicit_invalidation_impact(PropertyId::Overflow);
+    assert_explicit_invalidation_impact(PropertyId::Position);
+    assert_explicit_invalidation_impact(PropertyId::ZIndex);
+
     for property in layout_and_paint {
+        assert_explicit_invalidation_impact(property);
         assert_eq!(
             property.metadata().invalidation_impact,
             PropertyInvalidationImpact::layout_and_paint(),
@@ -719,6 +810,54 @@ fn shorthand_registry_keeps_outline_separate_from_supported_longhands() {
     assert_eq!(PropertyId::from_name("outline"), None);
     assert_eq!(property_registry().lookup("outline"), None);
     assert_eq!(registry.lookup("border"), None);
+}
+
+#[test]
+fn supported_shorthand_outputs_are_registered_impact_backed_longhands() {
+    let longhand_universe = PropertyId::ALL.into_iter().collect::<BTreeSet<_>>();
+
+    for shorthand in shorthand_registry().entries() {
+        assert_eq!(
+            PropertyId::from_name(shorthand.name()),
+            None,
+            "{} must remain a shorthand, not a supported longhand",
+            shorthand.name()
+        );
+        assert_eq!(
+            property_registry().lookup(shorthand.name()),
+            None,
+            "{} must not enter the longhand registry",
+            shorthand.name()
+        );
+        assert!(
+            !shorthand.longhands().is_empty(),
+            "{} shorthand must expand into registered longhands",
+            shorthand.name()
+        );
+
+        let mut expansion_ids = BTreeSet::new();
+        for &property in shorthand.longhands() {
+            assert!(
+                longhand_universe.contains(&property),
+                "{} shorthand emitted unsupported longhand {}",
+                shorthand.name(),
+                property.name()
+            );
+            assert_eq!(
+                property_registry().lookup_id(property.name()),
+                Some(property),
+                "{} shorthand emitted a longhand missing registry lookup",
+                shorthand.name()
+            );
+            assert!(
+                expansion_ids.insert(property),
+                "{} shorthand emitted duplicate longhand {}",
+                shorthand.name(),
+                property.name()
+            );
+            assert_explicit_invalidation_impact(property);
+        }
+    }
 }
 
 #[test]

--- a/crates/css/tests/property_registry_golden.rs
+++ b/crates/css/tests/property_registry_golden.rs
@@ -1,4 +1,4 @@
-use css::property_registry_metadata_debug_snapshot;
+use css::{property_registry, property_registry_metadata_debug_snapshot};
 
 #[test]
 fn property_registry_metadata_snapshot_is_deterministic() {
@@ -6,4 +6,22 @@ fn property_registry_metadata_snapshot_is_deterministic() {
         property_registry_metadata_debug_snapshot(),
         include_str!("fixtures/properties/registry_metadata.snap"),
     );
+}
+
+#[test]
+fn property_registry_metadata_snapshot_exposes_every_invalidation_impact() {
+    let snapshot = property_registry_metadata_debug_snapshot();
+    let impact_lines = snapshot
+        .lines()
+        .filter_map(|line| line.strip_prefix("  invalidation-impact: "))
+        .collect::<Vec<_>>();
+
+    assert_eq!(impact_lines.len(), property_registry().entries().len());
+    for (registration, impact_label) in property_registry().entries().iter().zip(impact_lines) {
+        assert!(
+            !impact_label.is_empty(),
+            "{} must expose invalidation impact in registry debug output",
+            registration.name()
+        );
+    }
 }

--- a/docs/css/ad4-css-property-registry-longhand-metadata.md
+++ b/docs/css/ad4-css-property-registry-longhand-metadata.md
@@ -179,6 +179,12 @@ Adding a supported longhand requires:
 7. Update docs and the feature gap tracker when the supported feature set or
    extension point changes.
 
+The supported-longhand coverage tests intentionally cross-check
+`PropertyId::ALL`, registry entries, lookup data, shorthand longhand outputs,
+and registry metadata snapshots. A new supported longhand is incomplete until
+it appears in all required registry surfaces and exposes a non-empty explicit
+invalidation impact label in the debug snapshot.
+
 Do not add property behavior directly to Browser/runtime, Layout, Paint, or
 GFX. If a downstream subsystem needs a new CSS fact, model it in CSS metadata
 or computed values first.

--- a/docs/css/ad7-css-owned-invalidation-impact-classification.md
+++ b/docs/css/ad7-css-owned-invalidation-impact-classification.md
@@ -148,6 +148,18 @@ Targeted CSS tests verify:
 - computed-style comparison projects property flags deterministically;
 - unknown document shape stays conservative.
 
+AD7 follow-up coverage treats the supported longhand source of truth as the
+relationship between `PropertyId::ALL`, `property_registry().entries()`,
+registry lookup data, and supported shorthand outputs. Tests must fail when a
+supported longhand is added without a registry registration, lookup entry,
+explicit `PropertyInvalidationImpact`, or deterministic debug snapshot impact
+label.
+
+Shorthands remain outside the supported longhand registry. A supported
+shorthand is valid only by expanding into registered longhands, and those
+longhands must carry the same explicit impact metadata as directly authored
+longhand declarations.
+
 Browser/runtime tests verify:
 
 - paint-only CSS-owned impact can avoid relayout through the real retained


### PR DESCRIPTION
Resolves #1294 