### PR TITLE
AF2: reconcile selector diagnostics with CSS model integration

### DIFF
--- a/crates/css/src/cascade/tests/document.rs
+++ b/crates/css/src/cascade/tests/document.rs
@@ -4,7 +4,8 @@ use super::super::{
 };
 use super::support::{element, namespaced_element, stylesheet};
 use crate::{
-    CascadePropertyId, CascadeSpecificity, ResolvedValueSource, StylesheetCascadeInput,
+    CascadePropertyId, CascadeRuleMatch, CascadeSpecificity, ResolvedValueSource, Rule,
+    SelectorDomIndex, SelectorMatchability, SelectorMatchingContext, StylesheetCascadeInput,
     resolve_document_styles_from_cascade_inputs,
 };
 
@@ -149,6 +150,43 @@ fn resolve_document_styles_produces_structured_output_without_mutating_dom() {
             .source(),
         &ResolvedValueSource::Initial(crate::InitialStyleValue::DisplayInline)
     );
+}
+
+#[test]
+fn parser_produced_invalid_and_unsupported_rules_are_non_applicable_to_cascade() {
+    let sheet = stylesheet("a:hover { color: red; } [lang=] { color: blue; }");
+    let dom = element("a", Vec::new(), Vec::new());
+    let index = SelectorDomIndex::from_root(&dom);
+    let context = SelectorMatchingContext::new(&index);
+    let element = index.elements().next().expect("indexed element");
+
+    let expected = [
+        SelectorMatchability::Unsupported,
+        SelectorMatchability::Invalid,
+    ];
+    let mut checked = 0;
+
+    for (rule_index, rule) in sheet.stylesheet.rules.iter().enumerate() {
+        let Rule::Style(rule) = rule else {
+            continue;
+        };
+
+        let outcome = context
+            .match_selector_list(element, &rule.selectors)
+            .expect("selector matching should not hit a limit");
+        assert_eq!(outcome.matchability(), expected[checked]);
+        assert!(!outcome.matched_any());
+
+        let rule_match = CascadeRuleMatch {
+            stylesheet_index: 0,
+            rule_index: rule_index as u32,
+            outcome,
+        };
+        assert!(!rule_match.contributes_candidates());
+        checked += 1;
+    }
+
+    assert_eq!(checked, expected.len());
 }
 
 #[test]

--- a/crates/css/src/model/entry.rs
+++ b/crates/css/src/model/entry.rs
@@ -4,10 +4,12 @@ use super::{
     Rule, StyleRule, Stylesheet, StylesheetParse, ValueBlock, ValueComponent, ValueFunction,
     ValueSymbol, ValueText, ValueToken,
 };
-use crate::selectors::parse_selector_list_with_limits;
+use crate::selectors::{
+    SelectorDiagnosticClass, SelectorDiagnosticLevel, parse_selector_list_with_limits,
+};
 use crate::syntax::{
     self, CssComponentValue, CssInput, CssParseOrigin, CssRule, CssToken, CssTokenKind,
-    CssTokenText, ParseOptions,
+    CssTokenText, DiagnosticKind, DiagnosticSeverity, ParseOptions, ParseStats, SyntaxDiagnostic,
 };
 
 /// Parse a stylesheet directly into the engine-facing rule model using default
@@ -22,13 +24,22 @@ pub fn parse_stylesheet(input: &str) -> Stylesheet {
 /// point does not use compatibility adapters or raw-string reparsing.
 pub fn parse_stylesheet_with_options(input: &str, options: &ParseOptions) -> StylesheetParse {
     let parse = syntax::parse_stylesheet_with_options(input, options);
-    let stylesheet = build_stylesheet(&parse.input, &parse.stylesheet, options.origin, options);
+    let mut diagnostics = parse.diagnostics;
+    let mut stats = parse.stats;
+    let stylesheet = build_stylesheet(
+        &parse.input,
+        &parse.stylesheet,
+        options.origin,
+        options,
+        &mut diagnostics,
+        &mut stats,
+    );
 
     StylesheetParse {
         input: parse.input,
         stylesheet,
-        diagnostics: parse.diagnostics,
-        stats: parse.stats,
+        diagnostics,
+        stats,
     }
 }
 
@@ -60,6 +71,8 @@ fn build_stylesheet(
     stylesheet: &syntax::CssStylesheet,
     origin: CssParseOrigin,
     options: &ParseOptions,
+    diagnostics: &mut Vec<SyntaxDiagnostic>,
+    stats: &mut ParseStats,
 ) -> Stylesheet {
     Stylesheet {
         origin,
@@ -67,18 +80,29 @@ fn build_stylesheet(
         rules: stylesheet
             .rules
             .iter()
-            .map(|rule| build_rule(input, rule, options))
+            .map(|rule| build_rule(input, rule, options, diagnostics, stats))
             .collect(),
     }
 }
 
-fn build_rule(input: &CssInput, rule: &CssRule, options: &ParseOptions) -> Rule {
+fn build_rule(
+    input: &CssInput,
+    rule: &CssRule,
+    options: &ParseOptions,
+    diagnostics: &mut Vec<SyntaxDiagnostic>,
+    stats: &mut ParseStats,
+) -> Rule {
     match rule {
-        CssRule::Qualified(rule) => Rule::Style(StyleRule {
-            span: rule.span,
-            selectors: parse_selector_list_with_limits(input, &rule.prelude, &options.limits),
-            declarations: build_declaration_block(input, &rule.block),
-        }),
+        CssRule::Qualified(rule) => {
+            let selectors = parse_selector_list_with_limits(input, &rule.prelude, &options.limits);
+            append_selector_diagnostic(&selectors, rule.span, options, diagnostics, stats);
+
+            Rule::Style(StyleRule {
+                span: rule.span,
+                selectors,
+                declarations: build_declaration_block(input, &rule.block),
+            })
+        }
         CssRule::At(rule) => Rule::At(AtRule {
             span: rule.span,
             name: canonical_name(input, &rule.name),
@@ -95,6 +119,47 @@ fn build_rule(input: &CssInput, rule: &CssRule, options: &ParseOptions) -> Rule 
             }),
         }),
     }
+}
+
+fn append_selector_diagnostic(
+    selectors: &crate::selectors::SelectorListParseResult,
+    rule_span: crate::syntax::CssSpan,
+    options: &ParseOptions,
+    diagnostics: &mut Vec<SyntaxDiagnostic>,
+    stats: &mut ParseStats,
+) {
+    let Some(diagnostic) = selectors.diagnostic() else {
+        return;
+    };
+
+    stats.diagnostics_emitted = stats.diagnostics_emitted.saturating_add(1);
+    if diagnostic.class() == SelectorDiagnosticClass::LimitExceeded {
+        stats.hit_limit = true;
+    }
+
+    if !options.collect_diagnostics || diagnostics.len() >= options.limits.max_diagnostics {
+        return;
+    }
+
+    let kind = match diagnostic.class() {
+        SelectorDiagnosticClass::EmptySelectorList => DiagnosticKind::EmptySelectorList,
+        SelectorDiagnosticClass::InvalidSelector => DiagnosticKind::InvalidSelector,
+        SelectorDiagnosticClass::UnsupportedSelector => DiagnosticKind::UnsupportedSelector,
+        SelectorDiagnosticClass::InvariantViolation => DiagnosticKind::InvariantViolation,
+        SelectorDiagnosticClass::LimitExceeded => DiagnosticKind::LimitExceeded,
+    };
+    let severity = match diagnostic.level() {
+        SelectorDiagnosticLevel::Warning => DiagnosticSeverity::Warning,
+        SelectorDiagnosticLevel::Error => DiagnosticSeverity::Error,
+    };
+    let byte_offset = diagnostic.span().unwrap_or(rule_span).start;
+
+    diagnostics.push(SyntaxDiagnostic {
+        severity,
+        kind,
+        byte_offset,
+        message: diagnostic.stable_message(),
+    });
 }
 
 fn canonical_name(input: &CssInput, text: &CssTokenText) -> Option<String> {

--- a/crates/css/src/model/tests.rs
+++ b/crates/css/src/model/tests.rs
@@ -4,7 +4,9 @@ use super::{
     serialize_value_for_snapshot,
 };
 use crate::selectors::SelectorListParseResult;
-use crate::syntax::{CssBlockKind, CssNumericKind, ParseOptions};
+use crate::syntax::{
+    CssBlockKind, CssNumericKind, DiagnosticKind, DiagnosticSeverity, ParseOptions,
+};
 
 #[test]
 fn model_stylesheet_preserves_rule_order_and_supported_rule_kinds() {
@@ -389,6 +391,96 @@ fn model_style_rules_carry_structured_selector_results() {
         invalid.selectors,
         SelectorListParseResult::Invalid(_)
     ));
+}
+
+#[test]
+fn model_projects_selector_diagnostics_in_model_traversal_order() {
+    let source = "a:is(.hero) { color: red; } div; [lang=] { color: blue; }";
+    let parse = parse_stylesheet_with_options(source, &ParseOptions::stylesheet());
+
+    assert_eq!(parse.diagnostics.len(), 3);
+    assert_eq!(parse.diagnostics[0].kind, DiagnosticKind::UnexpectedToken);
+    assert_eq!(
+        parse.diagnostics[1].kind,
+        DiagnosticKind::UnsupportedSelector
+    );
+    assert_eq!(parse.diagnostics[1].severity, DiagnosticSeverity::Warning);
+    assert_eq!(parse.diagnostics[2].kind, DiagnosticKind::InvalidSelector);
+    assert_eq!(parse.diagnostics[2].severity, DiagnosticSeverity::Error);
+
+    assert_eq!(parse.diagnostics[1].byte_offset, 0);
+    assert_eq!(
+        parse.diagnostics[1].message,
+        "unsupported selector feature(s): functional-pseudo-class, forgiving-selector-list"
+    );
+    assert_eq!(
+        parse.diagnostics[2].byte_offset,
+        source.find("[lang=]").unwrap()
+    );
+    assert_eq!(
+        parse.diagnostics[2].message,
+        "invalid selector: missing-attribute-value"
+    );
+    assert_eq!(parse.stats.diagnostics_emitted, 3);
+}
+
+#[test]
+fn model_preserves_selector_limit_accounting_and_diagnostic_caps() {
+    let mut limited = ParseOptions::stylesheet();
+    limited.limits.max_selector_segments_per_selector = 0;
+    let limit = parse_stylesheet_with_options("div { color: red; }", &limited);
+
+    assert_eq!(limit.diagnostics.len(), 1);
+    assert_eq!(limit.diagnostics[0].kind, DiagnosticKind::LimitExceeded);
+    assert_eq!(limit.diagnostics[0].severity, DiagnosticSeverity::Error);
+    assert!(limit.stats.hit_limit);
+    assert_eq!(limit.stats.diagnostics_emitted, 1);
+
+    let mut capped = ParseOptions::stylesheet();
+    capped.limits.max_diagnostics = 0;
+    let capped_parse = parse_stylesheet_with_options("a:hover { color: red; }", &capped);
+    assert!(capped_parse.diagnostics.is_empty());
+    assert_eq!(capped_parse.stats.diagnostics_emitted, 1);
+
+    let mut disabled = ParseOptions::stylesheet();
+    disabled.collect_diagnostics = false;
+    let disabled_parse = parse_stylesheet_with_options("a:hover { color: red; }", &disabled);
+    assert!(disabled_parse.diagnostics.is_empty());
+    assert_eq!(disabled_parse.stats.diagnostics_emitted, 1);
+}
+
+#[test]
+fn model_retains_invalid_and_unsupported_selector_states_and_diagnostics() {
+    let parse = parse_stylesheet_with_options(
+        "a:hover { color: red; } [lang=] { color: blue; }",
+        &ParseOptions::stylesheet(),
+    );
+    let Rule::Style(unsupported) = &parse.stylesheet.rules[0] else {
+        panic!("expected unsupported style rule");
+    };
+    let Rule::Style(invalid) = &parse.stylesheet.rules[1] else {
+        panic!("expected invalid style rule");
+    };
+
+    assert!(matches!(
+        unsupported.selectors,
+        SelectorListParseResult::Unsupported(_)
+    ));
+    assert!(matches!(
+        invalid.selectors,
+        SelectorListParseResult::Invalid(_)
+    ));
+    assert_eq!(
+        parse
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.kind)
+            .collect::<Vec<_>>(),
+        vec![
+            DiagnosticKind::UnsupportedSelector,
+            DiagnosticKind::InvalidSelector
+        ]
+    );
 }
 
 fn declaration_value_contains_important(values: &[ValueComponent]) -> bool {

--- a/crates/css/src/selectors/diagnostics.rs
+++ b/crates/css/src/selectors/diagnostics.rs
@@ -1,0 +1,178 @@
+use crate::syntax::CssSpan;
+
+use super::{InvalidSelectorReason, SelectorListParseResult, UnsupportedSelectorFeature};
+
+/// Selector-owned diagnostic classification exposed to the model boundary.
+///
+/// The selector subsystem decides this normalized semantic class. The model
+/// only translates it into the shared syntax diagnostic transport.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SelectorDiagnosticClass {
+    EmptySelectorList,
+    InvalidSelector,
+    UnsupportedSelector,
+    InvariantViolation,
+    LimitExceeded,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SelectorDiagnosticLevel {
+    Warning,
+    Error,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SelectorDiagnosticDetail<'a> {
+    EmptySelectorList,
+    Invalid(InvalidSelectorReason),
+    Unsupported(&'a [UnsupportedSelectorFeature]),
+    InvariantViolation,
+    LimitExceeded,
+}
+
+/// Typed selector diagnostic information before projection into
+/// `crate::syntax::SyntaxDiagnostic`.
+pub(crate) struct SelectorDiagnostic<'a> {
+    span: Option<CssSpan>,
+    detail: SelectorDiagnosticDetail<'a>,
+}
+
+impl SelectorListParseResult {
+    pub(crate) fn diagnostic(&self) -> Option<SelectorDiagnostic<'_>> {
+        match self {
+            Self::Parsed(_) => None,
+            Self::Unsupported(list) => Some(SelectorDiagnostic {
+                span: list.span(),
+                detail: SelectorDiagnosticDetail::Unsupported(list.features()),
+            }),
+            Self::Invalid(list) => {
+                let detail = match list.reason() {
+                    InvalidSelectorReason::EmptySelectorList => {
+                        SelectorDiagnosticDetail::EmptySelectorList
+                    }
+                    InvalidSelectorReason::ResourceLimitExceeded => {
+                        SelectorDiagnosticDetail::LimitExceeded
+                    }
+                    InvalidSelectorReason::InvariantViolation => {
+                        SelectorDiagnosticDetail::InvariantViolation
+                    }
+                    InvalidSelectorReason::EmptyCompoundSelector
+                    | InvalidSelectorReason::LeadingCombinator
+                    | InvalidSelectorReason::TrailingCombinator
+                    | InvalidSelectorReason::RepeatedCombinator
+                    | InvalidSelectorReason::MultipleTypeSelectors
+                    | InvalidSelectorReason::MissingAttributeName
+                    | InvalidSelectorReason::MissingAttributeValue
+                    | InvalidSelectorReason::UnexpectedComponentValue => {
+                        SelectorDiagnosticDetail::Invalid(list.reason())
+                    }
+                };
+
+                Some(SelectorDiagnostic {
+                    span: list.span(),
+                    detail,
+                })
+            }
+        }
+    }
+}
+
+impl<'a> SelectorDiagnostic<'a> {
+    pub(crate) fn span(&self) -> Option<CssSpan> {
+        self.span
+    }
+
+    pub(crate) fn class(&self) -> SelectorDiagnosticClass {
+        match self.detail {
+            SelectorDiagnosticDetail::EmptySelectorList => {
+                SelectorDiagnosticClass::EmptySelectorList
+            }
+            SelectorDiagnosticDetail::Invalid(_) => SelectorDiagnosticClass::InvalidSelector,
+            SelectorDiagnosticDetail::Unsupported(_) => {
+                SelectorDiagnosticClass::UnsupportedSelector
+            }
+            SelectorDiagnosticDetail::InvariantViolation => {
+                SelectorDiagnosticClass::InvariantViolation
+            }
+            SelectorDiagnosticDetail::LimitExceeded => SelectorDiagnosticClass::LimitExceeded,
+        }
+    }
+
+    pub(crate) fn level(&self) -> SelectorDiagnosticLevel {
+        match self.detail {
+            SelectorDiagnosticDetail::Unsupported(_) => SelectorDiagnosticLevel::Warning,
+            SelectorDiagnosticDetail::EmptySelectorList
+            | SelectorDiagnosticDetail::Invalid(_)
+            | SelectorDiagnosticDetail::InvariantViolation
+            | SelectorDiagnosticDetail::LimitExceeded => SelectorDiagnosticLevel::Error,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn detail(&self) -> &SelectorDiagnosticDetail<'a> {
+        &self.detail
+    }
+
+    pub(crate) fn stable_message(&self) -> String {
+        match &self.detail {
+            SelectorDiagnosticDetail::EmptySelectorList => "empty selector list".to_string(),
+            SelectorDiagnosticDetail::Invalid(reason) => {
+                format!("invalid selector: {}", reason.stable_label())
+            }
+            SelectorDiagnosticDetail::Unsupported(features) => {
+                let labels = features
+                    .iter()
+                    .map(|feature| feature.stable_label())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("unsupported selector feature(s): {labels}")
+            }
+            SelectorDiagnosticDetail::InvariantViolation => {
+                format!(
+                    "selector invariant violation: {}",
+                    InvalidSelectorReason::InvariantViolation.stable_label()
+                )
+            }
+            SelectorDiagnosticDetail::LimitExceeded => {
+                format!(
+                    "selector resource limit exceeded: {}",
+                    InvalidSelectorReason::ResourceLimitExceeded.stable_label()
+                )
+            }
+        }
+    }
+}
+
+impl InvalidSelectorReason {
+    pub(crate) const fn stable_label(self) -> &'static str {
+        match self {
+            Self::EmptySelectorList => "empty-selector-list",
+            Self::EmptyCompoundSelector => "empty-compound-selector",
+            Self::LeadingCombinator => "leading-combinator",
+            Self::TrailingCombinator => "trailing-combinator",
+            Self::RepeatedCombinator => "repeated-combinator",
+            Self::MultipleTypeSelectors => "multiple-type-selectors",
+            Self::MissingAttributeName => "missing-attribute-name",
+            Self::MissingAttributeValue => "missing-attribute-value",
+            Self::UnexpectedComponentValue => "unexpected-component-value",
+            Self::InvariantViolation => "invariant-violation",
+            Self::ResourceLimitExceeded => "resource-limit-exceeded",
+        }
+    }
+}
+
+impl UnsupportedSelectorFeature {
+    pub(crate) const fn stable_label(self) -> &'static str {
+        match self {
+            Self::Namespace => "namespace",
+            Self::AttributeCaseModifier => "attribute-case-modifier",
+            Self::PseudoClass => "pseudo-class",
+            Self::FunctionalPseudoClass => "functional-pseudo-class",
+            Self::PseudoElement => "pseudo-element",
+            Self::RelativeSelector => "relative-selector",
+            Self::NestingSelector => "nesting-selector",
+            Self::ColumnCombinator => "column-combinator",
+            Self::ForgivingSelectorList => "forgiving-selector-list",
+        }
+    }
+}

--- a/crates/css/src/selectors/matching/tests/matchability.rs
+++ b/crates/css/src/selectors/matching/tests/matchability.rs
@@ -9,7 +9,8 @@ fn parse_results_expose_matchability_without_collapsing_invalidity() {
         crate::selectors::UnsupportedSelectorList::from_features(
             None,
             [UnsupportedSelectorFeature::PseudoClass],
-        ),
+        )
+        .expect("unsupported feature list must be non-empty"),
     );
     let invalid = crate::selectors::SelectorListParseResult::Invalid(
         crate::selectors::InvalidSelectorList::new(None, InvalidSelectorReason::EmptySelectorList),

--- a/crates/css/src/selectors/matching/tests/simple_matching.rs
+++ b/crates/css/src/selectors/matching/tests/simple_matching.rs
@@ -207,7 +207,8 @@ fn matching_context_match_selector_list_preserves_non_matchable_parse_states() {
         crate::selectors::UnsupportedSelectorList::from_features(
             None,
             [UnsupportedSelectorFeature::PseudoClass],
-        ),
+        )
+        .expect("unsupported feature list must be non-empty"),
     );
     let invalid = crate::selectors::SelectorListParseResult::Invalid(
         crate::selectors::InvalidSelectorList::new(None, InvalidSelectorReason::EmptySelectorList),

--- a/crates/css/src/selectors/mod.rs
+++ b/crates/css/src/selectors/mod.rs
@@ -19,6 +19,7 @@
 
 mod attribute;
 mod complex;
+mod diagnostics;
 #[cfg(any(test, feature = "css-fuzzing"))]
 pub mod fuzz;
 pub mod matching;
@@ -33,6 +34,8 @@ mod tests;
 
 mod validation;
 mod values;
+
+pub(crate) use diagnostics::{SelectorDiagnosticClass, SelectorDiagnosticLevel};
 
 pub(crate) use self::serialize::write_selector_parse_result_snapshot_body;
 pub use self::serialize::{

--- a/crates/css/src/selectors/parse_result.rs
+++ b/crates/css/src/selectors/parse_result.rs
@@ -123,10 +123,13 @@ pub struct UnsupportedSelectorList {
 impl UnsupportedSelectorList {
     /// Construct an unsupported selector list with deduplicated feature
     /// categories preserved in first-encounter order.
+    ///
+    /// Returns `None` when no unsupported feature was supplied; an
+    /// `UnsupportedSelectorList` is never valid without at least one feature.
     pub fn from_features(
         span: Option<CssSpan>,
         features: impl IntoIterator<Item = UnsupportedSelectorFeature>,
-    ) -> Self {
+    ) -> Option<Self> {
         let mut list = Self {
             span,
             features: Vec::new(),
@@ -134,7 +137,7 @@ impl UnsupportedSelectorList {
         for feature in features {
             list.push_feature(feature);
         }
-        list
+        (!list.features.is_empty()).then_some(list)
     }
 
     pub fn span(&self) -> Option<CssSpan> {
@@ -159,9 +162,10 @@ impl UnsupportedSelectorList {
 /// Handling strategy for syntactically valid but unsupported selector input.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UnsupportedSelectorHandling {
-    /// Preserve the selector list as unsupported and non-matchable, while
-    /// keeping the source eligible for future support without reparsing raw
-    /// stylesheet text.
+    /// Preserve the selector list as unsupported and non-matchable while
+    /// retaining its source span and unsupported feature categories. Future
+    /// support may require reparsing the preserved source/prelude because this
+    /// result is not a lossless unsupported-selector AST.
     PreserveAsUnsupported,
 }
 

--- a/crates/css/src/selectors/parser/list.rs
+++ b/crates/css/src/selectors/parser/list.rs
@@ -70,9 +70,13 @@ pub fn parse_selector_list_with_limits(
     }
 
     if !unsupported.is_empty() {
-        return SelectorListParseResult::Unsupported(UnsupportedSelectorList::from_features(
+        if let Some(list) = UnsupportedSelectorList::from_features(overall_span, unsupported) {
+            return SelectorListParseResult::Unsupported(list);
+        }
+
+        return SelectorListParseResult::Invalid(InvalidSelectorList::new(
             overall_span,
-            unsupported,
+            InvalidSelectorReason::InvariantViolation,
         ));
     }
 

--- a/crates/css/src/selectors/serialize.rs
+++ b/crates/css/src/selectors/serialize.rs
@@ -1,7 +1,7 @@
 use super::{
     AttributeMatcher, AttributeSelector, AttributeValue, Combinator, ComplexSelector,
-    CompoundSelector, InvalidSelectorReason, SelectorList, SelectorListParseResult, Specificity,
-    SubclassSelector, TypeSelector, UnsupportedSelectorFeature,
+    CompoundSelector, SelectorList, SelectorListParseResult, Specificity, SubclassSelector,
+    TypeSelector,
 };
 use crate::syntax::CssSpan;
 use std::fmt::Write;
@@ -54,7 +54,7 @@ pub(crate) fn write_selector_parse_result_snapshot_body(
                 writeln!(
                     out,
                     "{indent_str}feature[{feature_index}]: {}",
-                    unsupported_feature_label(*feature)
+                    feature.stable_label()
                 )
                 .expect("write unsupported feature");
             }
@@ -63,12 +63,8 @@ pub(crate) fn write_selector_parse_result_snapshot_body(
             writeln!(out, "{indent_str}result: invalid").expect("write invalid result");
             writeln!(out, "{indent_str}span: {}", span_label(list.span()))
                 .expect("write invalid span");
-            writeln!(
-                out,
-                "{indent_str}reason: {}",
-                invalid_reason_label(list.reason())
-            )
-            .expect("write invalid reason");
+            writeln!(out, "{indent_str}reason: {}", list.reason().stable_label())
+                .expect("write invalid reason");
         }
     }
 }
@@ -250,36 +246,6 @@ fn attribute_matcher_label(matcher: AttributeMatcher) -> &'static str {
         AttributeMatcher::Prefix => "prefix",
         AttributeMatcher::Suffix => "suffix",
         AttributeMatcher::Substring => "substring",
-    }
-}
-
-fn unsupported_feature_label(feature: UnsupportedSelectorFeature) -> &'static str {
-    match feature {
-        UnsupportedSelectorFeature::Namespace => "namespace",
-        UnsupportedSelectorFeature::AttributeCaseModifier => "attribute-case-modifier",
-        UnsupportedSelectorFeature::PseudoClass => "pseudo-class",
-        UnsupportedSelectorFeature::FunctionalPseudoClass => "functional-pseudo-class",
-        UnsupportedSelectorFeature::PseudoElement => "pseudo-element",
-        UnsupportedSelectorFeature::RelativeSelector => "relative-selector",
-        UnsupportedSelectorFeature::NestingSelector => "nesting-selector",
-        UnsupportedSelectorFeature::ColumnCombinator => "column-combinator",
-        UnsupportedSelectorFeature::ForgivingSelectorList => "forgiving-selector-list",
-    }
-}
-
-fn invalid_reason_label(reason: InvalidSelectorReason) -> &'static str {
-    match reason {
-        InvalidSelectorReason::EmptySelectorList => "empty-selector-list",
-        InvalidSelectorReason::EmptyCompoundSelector => "empty-compound-selector",
-        InvalidSelectorReason::LeadingCombinator => "leading-combinator",
-        InvalidSelectorReason::TrailingCombinator => "trailing-combinator",
-        InvalidSelectorReason::RepeatedCombinator => "repeated-combinator",
-        InvalidSelectorReason::MultipleTypeSelectors => "multiple-type-selectors",
-        InvalidSelectorReason::MissingAttributeName => "missing-attribute-name",
-        InvalidSelectorReason::MissingAttributeValue => "missing-attribute-value",
-        InvalidSelectorReason::UnexpectedComponentValue => "unexpected-component-value",
-        InvalidSelectorReason::InvariantViolation => "invariant-violation",
-        InvalidSelectorReason::ResourceLimitExceeded => "resource-limit-exceeded",
     }
 }
 

--- a/crates/css/src/selectors/tests/parse_result.rs
+++ b/crates/css/src/selectors/tests/parse_result.rs
@@ -1,3 +1,6 @@
+use super::super::diagnostics::{
+    SelectorDiagnosticClass, SelectorDiagnosticDetail, SelectorDiagnosticLevel,
+};
 use super::super::{
     InvalidSelectorList, InvalidSelectorReason, SelectorListParseResult,
     UnsupportedSelectorFeature, UnsupportedSelectorHandling, UnsupportedSelectorList,
@@ -8,14 +11,17 @@ use crate::syntax::CssInput;
 #[test]
 fn parse_result_states_are_explicit_and_snapshot_stable() {
     let unsupported_input = CssInput::from(":hover");
-    let unsupported = SelectorListParseResult::Unsupported(UnsupportedSelectorList::from_features(
-        unsupported_input.span(0, 6),
-        [
-            UnsupportedSelectorFeature::PseudoClass,
-            UnsupportedSelectorFeature::ForgivingSelectorList,
-            UnsupportedSelectorFeature::PseudoClass,
-        ],
-    ));
+    let unsupported = SelectorListParseResult::Unsupported(
+        UnsupportedSelectorList::from_features(
+            unsupported_input.span(0, 6),
+            [
+                UnsupportedSelectorFeature::PseudoClass,
+                UnsupportedSelectorFeature::ForgivingSelectorList,
+                UnsupportedSelectorFeature::PseudoClass,
+            ],
+        )
+        .expect("unsupported feature list must be non-empty"),
+    );
     assert!(unsupported.parsed().is_none());
     assert!(unsupported.unsupported().is_some());
     assert!(unsupported.invalid().is_none());
@@ -70,7 +76,8 @@ fn unsupported_feature_lists_are_deduplicated_in_first_encounter_order() {
             UnsupportedSelectorFeature::PseudoElement,
             UnsupportedSelectorFeature::FunctionalPseudoClass,
         ],
-    );
+    )
+    .expect("unsupported feature list must be non-empty");
 
     assert_eq!(
         list.features(),
@@ -83,11 +90,151 @@ fn unsupported_feature_lists_are_deduplicated_in_first_encounter_order() {
 }
 
 #[test]
+fn unsupported_feature_lists_cannot_be_constructed_empty() {
+    assert!(UnsupportedSelectorList::from_features(None, []).is_none());
+}
+
+#[test]
 fn unsupported_selector_lists_expose_explicit_handling_strategy() {
     let list = unsupported_selector("a:is(.x)");
 
     assert_eq!(
         list.handling(),
         UnsupportedSelectorHandling::PreserveAsUnsupported
+    );
+}
+
+#[test]
+fn selector_diagnostics_normalize_invalid_reasons_at_the_selector_boundary() {
+    let cases = [
+        (
+            InvalidSelectorReason::EmptySelectorList,
+            SelectorDiagnosticClass::EmptySelectorList,
+            SelectorDiagnosticLevel::Error,
+        ),
+        (
+            InvalidSelectorReason::ResourceLimitExceeded,
+            SelectorDiagnosticClass::LimitExceeded,
+            SelectorDiagnosticLevel::Error,
+        ),
+        (
+            InvalidSelectorReason::InvariantViolation,
+            SelectorDiagnosticClass::InvariantViolation,
+            SelectorDiagnosticLevel::Error,
+        ),
+        (
+            InvalidSelectorReason::MissingAttributeValue,
+            SelectorDiagnosticClass::InvalidSelector,
+            SelectorDiagnosticLevel::Error,
+        ),
+    ];
+
+    for (reason, expected_class, expected_level) in cases {
+        let result = SelectorListParseResult::Invalid(InvalidSelectorList::new(None, reason));
+        let diagnostic = result.diagnostic().expect("invalid selector diagnostic");
+
+        assert_eq!(diagnostic.class(), expected_class);
+        assert_eq!(diagnostic.level(), expected_level);
+        assert!(match (reason, diagnostic.detail()) {
+            (
+                InvalidSelectorReason::EmptySelectorList,
+                SelectorDiagnosticDetail::EmptySelectorList,
+            ) => true,
+            (reason, SelectorDiagnosticDetail::Invalid(actual)) => *actual == reason,
+            (
+                InvalidSelectorReason::InvariantViolation,
+                SelectorDiagnosticDetail::InvariantViolation,
+            ) => true,
+            (
+                InvalidSelectorReason::ResourceLimitExceeded,
+                SelectorDiagnosticDetail::LimitExceeded,
+            ) => true,
+            _ => false,
+        });
+    }
+}
+
+#[test]
+fn selector_diagnostics_normalize_unsupported_features_at_the_selector_boundary() {
+    let result = SelectorListParseResult::Unsupported(
+        UnsupportedSelectorList::from_features(
+            None,
+            [
+                UnsupportedSelectorFeature::FunctionalPseudoClass,
+                UnsupportedSelectorFeature::ForgivingSelectorList,
+            ],
+        )
+        .expect("unsupported feature list must be non-empty"),
+    );
+    let diagnostic = result
+        .diagnostic()
+        .expect("unsupported selector diagnostic");
+
+    assert_eq!(
+        diagnostic.class(),
+        SelectorDiagnosticClass::UnsupportedSelector
+    );
+    assert_eq!(diagnostic.level(), SelectorDiagnosticLevel::Warning);
+    assert!(matches!(
+        diagnostic.detail(),
+        SelectorDiagnosticDetail::Unsupported(features)
+            if *features == [
+                UnsupportedSelectorFeature::FunctionalPseudoClass,
+                UnsupportedSelectorFeature::ForgivingSelectorList,
+            ]
+    ));
+}
+
+#[test]
+fn selector_diagnostic_messages_use_canonical_selector_labels() {
+    let invalid = SelectorListParseResult::Invalid(InvalidSelectorList::new(
+        None,
+        InvalidSelectorReason::MissingAttributeValue,
+    ));
+    assert_eq!(
+        invalid
+            .diagnostic()
+            .expect("invalid selector diagnostic")
+            .stable_message(),
+        "invalid selector: missing-attribute-value"
+    );
+
+    let unsupported = SelectorListParseResult::Unsupported(
+        UnsupportedSelectorList::from_features(
+            None,
+            [UnsupportedSelectorFeature::FunctionalPseudoClass],
+        )
+        .expect("unsupported feature list must be non-empty"),
+    );
+    assert_eq!(
+        unsupported
+            .diagnostic()
+            .expect("unsupported selector diagnostic")
+            .stable_message(),
+        "unsupported selector feature(s): functional-pseudo-class"
+    );
+
+    let invariant = SelectorListParseResult::Invalid(InvalidSelectorList::new(
+        None,
+        InvalidSelectorReason::InvariantViolation,
+    ));
+    assert_eq!(
+        invariant
+            .diagnostic()
+            .expect("invariant selector diagnostic")
+            .stable_message(),
+        "selector invariant violation: invariant-violation"
+    );
+
+    let resource_limit = SelectorListParseResult::Invalid(InvalidSelectorList::new(
+        None,
+        InvalidSelectorReason::ResourceLimitExceeded,
+    ));
+    assert_eq!(
+        resource_limit
+            .diagnostic()
+            .expect("resource-limit selector diagnostic")
+            .stable_message(),
+        "selector resource limit exceeded: resource-limit-exceeded"
     );
 }

--- a/crates/css/tests/fixtures/model/selector_diagnostics.css
+++ b/crates/css/tests/fixtures/model/selector_diagnostics.css
@@ -1,0 +1,3 @@
+a:is(.hero) { color: red; }
+[lang=] { color: blue; }
+div:hover::before { color: green; }

--- a/crates/css/tests/fixtures/model/selector_diagnostics.snap
+++ b/crates/css/tests/fixtures/model/selector_diagnostics.snap
@@ -1,0 +1,52 @@
+version: 1
+model-stylesheet
+origin: stylesheet
+span: @0..88
+rule[0] style @0..27
+  selectors
+    result: unsupported
+    span: @0..12
+    feature[0]: functional-pseudo-class
+    feature[1]: forgiving-selector-list
+  declarations @12..27
+    declaration[0] @14..25
+      name(kind=standard, text="color") @14..19
+      value @20..24
+        - whitespace @20..21
+        - ident("red") @21..24
+      important @<none>
+rule[1] style @28..52
+  selectors
+    result: invalid
+    span: @28..35
+    reason: missing-attribute-value
+  declarations @36..52
+    declaration[0] @38..50
+      name(kind=standard, text="color") @38..43
+      value @44..49
+        - whitespace @44..45
+        - ident("blue") @45..49
+      important @<none>
+rule[2] style @53..88
+  selectors
+    result: unsupported
+    span: @53..71
+    feature[0]: pseudo-class
+    feature[1]: pseudo-element
+  declarations @71..88
+    declaration[0] @73..86
+      name(kind=standard, text="color") @73..78
+      value @79..85
+        - whitespace @79..80
+        - ident("green") @80..85
+      important @<none>
+diagnostics
+  - warning unsupported-selector @0
+  - error invalid-selector @28
+  - warning unsupported-selector @53
+stats
+  input_bytes: 88
+  rules_emitted: 3
+  declarations_emitted: 3
+  diagnostics_emitted: 3
+  hit_limit: false

--- a/crates/css/tests/model_golden.rs
+++ b/crates/css/tests/model_golden.rs
@@ -30,3 +30,15 @@ fn model_snapshot_golden_malformed_recovery() {
         include_str!("fixtures/model/malformed_recovery.snap"),
     );
 }
+
+#[test]
+fn model_snapshot_golden_selector_diagnostics() {
+    let parse = parse_stylesheet_with_options(
+        fixture_input(include_str!("fixtures/model/selector_diagnostics.css")),
+        &ParseOptions::stylesheet(),
+    );
+    assert_eq!(
+        serialize_stylesheet_parse_for_snapshot(&parse),
+        include_str!("fixtures/model/selector_diagnostics.snap"),
+    );
+}

--- a/docs/css/af1-selector-cascade-computed-style-architecture-contract.md
+++ b/docs/css/af1-selector-cascade-computed-style-architecture-contract.md
@@ -71,6 +71,14 @@ retains it directly as `Option<css::StyleInvalidationPlan>` and forwards it to
 CSS execution APIs. `None` is the sole representation of no style
 invalidation.
 
+Selector diagnostics remain CSS-owned semantic results. `css::selectors`
+normalizes invalid, unsupported, invariant, and resource-limit outcomes with
+typed details and severity. `css::model` mechanically projects those outcomes
+into the shared `SyntaxDiagnostic` transport while preserving syntax
+diagnostic encounter order and appending selector diagnostics in model
+style-rule traversal order. Browser/runtime does not interpret selector
+diagnostic classes or features.
+
 ## AD and AE integration
 
 AF consumes AD's registered property metadata, typed value model, shorthand

--- a/docs/css/af2-selector-ast-and-parser.md
+++ b/docs/css/af2-selector-ast-and-parser.md
@@ -1,0 +1,138 @@
+# AF2: Selector AST, Parser, And Selector Diagnostics
+
+Last updated: 2026-08-12
+Status: implemented
+
+AF2 completes the Milestone AF selector-parser boundary by reconciling the
+existing Milestone P selector AST/parser with the shared stylesheet diagnostic
+transport. It does not introduce a second selector AST or expand selector
+matching coverage.
+
+## Ownership
+
+`css::syntax` owns generic CSS tokenization, component values, stylesheet
+parsing, generic recovery, syntax diagnostics, and syntax limits.
+
+`css::selectors` owns selector-specific structure and semantics:
+
+- selector AST construction and parsing;
+- supported and unsupported selector policy;
+- invalid-selector classification;
+- selector source spans and source order;
+- typed selector diagnostic classes and levels;
+- typed invalid reasons and unsupported feature categories;
+- stable selector labels and selector diagnostic messages;
+- selector resource-limit classification;
+- selector snapshots.
+
+`css::model` stores `StyleRule::selectors` and mechanically projects
+selector-owned diagnostics into the shared `SyntaxDiagnostic` transport. It
+does not interpret selector grammar, invalid reasons, or unsupported features.
+
+## Existing Selector Foundation
+
+The permanent selector implementation was introduced by Milestone P under
+`crates/css/src/selectors` and includes:
+
+- selector lists;
+- complex and compound selectors;
+- type and universal selectors;
+- ID and class selectors;
+- attribute presence and supported comparison selectors;
+- descendant, child, next-sibling, and subsequent-sibling combinators;
+- explicit `Parsed`, `Unsupported`, and `Invalid` outcomes;
+- deterministic spans, specificity hooks, and snapshots.
+
+AF2 preserves that implementation unchanged except for the diagnostic boundary
+and canonical label reuse.
+
+## Selector Diagnostic Classification
+
+Before transport projection, `css::selectors` normalizes a parse result into a
+typed selector diagnostic descriptor. Its normalized classes are:
+
+- `EmptySelectorList`;
+- `InvalidSelector`;
+- `UnsupportedSelector`;
+- `InvariantViolation`;
+- `LimitExceeded`.
+
+The descriptor also carries a selector-owned warning/error level and typed
+details. Ordinary authored invalid selectors retain their typed
+`InvalidSelectorReason`; unsupported selectors retain ordered
+`UnsupportedSelectorFeature` values. Empty-selector-list,
+invariant-violation, and resource-limit outcomes are normalized into dedicated
+typed detail variants.
+
+The descriptor uses one typed detail state as the source for its normalized
+class, level, and stable message. Inconsistent class/detail/level combinations
+are therefore not representable. Unsupported selector lists also require at
+least one deduplicated unsupported feature. The public
+`UnsupportedSelectorList::from_features` constructor returns `None` for an
+empty input; all in-repository construction paths handle this explicitly.
+
+The model boundary maps normalized classes and levels mechanically to
+`DiagnosticKind` and `DiagnosticSeverity`. It does not derive policy from
+individual selector reasons or features.
+
+Internal selector span/IR failures remain `InvariantViolation` diagnostics.
+Selector resource exhaustion remains `LimitExceeded`. Authored malformed
+selectors remain `InvalidSelector`, and syntactically understood but unsupported
+selectors remain `UnsupportedSelector` warnings.
+
+## Diagnostic Ordering And Statistics
+
+Syntax diagnostics retain the exact encounter order emitted by
+`css::syntax`. AF2 does not globally sort diagnostics by byte offset.
+
+During model construction, selector diagnostics are projected as each style
+rule is traversed. They are appended in deterministic model style-rule/source
+order after the syntax diagnostic stream.
+
+The shared diagnostic transport stores a byte offset. Projection uses the
+selector descriptor span start, or the containing rule span start when the
+selector descriptor has no span.
+
+`ParseStats` remains structurally unchanged. `diagnostics_emitted` counts every
+classified diagnostic event even when diagnostics are disabled or storage is
+capped by `max_diagnostics`. Selector `LimitExceeded` classifications also set
+aggregate parse `hit_limit`.
+
+Selector messages are built only when a diagnostic will be retained. Stable
+selector labels are defined once on selector reason/feature types and are
+shared by selector snapshots and diagnostic messages. Derived Rust `Debug` is
+not a diagnostic or snapshot contract.
+
+## Applicability And Non-Goals
+
+Invalid and unsupported selector lists remain explicitly non-matchable and do
+not contribute cascade candidates. Selector lists are not partially salvaged.
+
+AF2 does not implement:
+
+- selector matching changes;
+- specificity changes;
+- pseudo-classes or pseudo-elements;
+- namespace selectors;
+- cascade or computed-style changes;
+- selector dependency invalidation;
+- a lossless unsupported-selector AST;
+- CSSOM, JavaScript style APIs, media queries, custom properties, animations,
+  or transitions.
+
+`UnsupportedSelectorList` currently retains its source span and normalized
+unsupported feature categories, not a lossless unsupported selector tree.
+Future support may therefore require reparsing the preserved source/prelude.
+
+## Contract Reconciliation
+
+The original N9 proposal for a second syntax-layer selector AST is superseded
+by the later Milestone P architecture. `css::selectors` is the permanent
+selector-specific AST/parser owner; `css::syntax` remains the generic syntax
+layer. N8, the syntax parser contract, O1, P6, AF1, and the feature-gap tracker
+must describe this same boundary.
+
+Validation coverage keeps the phase boundary explicit: the existing selector
+parser fuzz corpus protects selector parsing and classification, while AF2's
+model unit tests and model golden cover selector diagnostic projection. The
+parser corpus is not treated as coverage of the model diagnostic transport.

--- a/docs/css/n8-parser-contract-cutover.md
+++ b/docs/css/n8-parser-contract-cutover.md
@@ -98,10 +98,11 @@ only where the current cascade layer still requires them.
 
 Milestone N intentionally leaves these for later work:
 
-- selector syntax remains only partially structured; richer selector AST work is
-  queued separately
-- compatibility selector projection still exists because the cascade layer does
-  not yet consume selector AST nodes
+- selector matching and broader selector coverage remain later work; the
+  permanent selector AST/parser now belongs to `css::selectors` under
+  Milestone P and AF2
+- compatibility selector projection still exists only as a migration bridge
+  for consumers that have not moved to the selector model
 - declaration values are preserved as syntax-layer component values, not
   property-specific semantic value trees
 - at-rule semantics are still limited to structural parsing rather than full

--- a/docs/css/n9-selector-structure-expansion.md
+++ b/docs/css/n9-selector-structure-expansion.md
@@ -1,7 +1,7 @@
 # N9: Expand Selector Syntax Structure Beyond Compatibility Projection
 
-Last updated: 2026-04-05  
-Status: queued after N8
+Last updated: 2026-08-12
+Status: superseded by Milestone P and AF2
 
 Tracker note:
 - this issue was originally queued in-repo under `N5`
@@ -14,9 +14,20 @@ Tracker note:
 - it was then renumbered to `N9` once parser contract cutover/documentation
   became the implemented `N8`
 
-## Issue
+## Historical status
 
-Introduce a real structured selector syntax layer so stylesheet parsing no
+This proposal is no longer an active implementation direction. Its original
+motivation—to prevent `CompatSelector` from becoming the permanent selector
+representation—was fulfilled by Milestone P and reconciled by AF2.
+
+`css::selectors` now owns the permanent selector AST/parser and
+`StyleRule::selectors` stores its structured parse result. `css::syntax` keeps
+its generic token/component-value/recovery ownership. AF2 does not introduce a
+second selector AST under `css::syntax`.
+
+## Original issue
+
+Introduce a real structured selector representation so stylesheet parsing no
 longer depends on projecting qualified-rule preludes directly into the limited
 `CompatSelector` model used by the current cascade path.
 
@@ -26,15 +37,15 @@ selector structure: qualified-rule preludes are preserved as generic component
 values, but selector syntax is not yet represented explicitly inside the
 syntax-layer AST.
 
-## Why This Exists
+## Original rationale
 
-The current parser architecture is now strong on the rule/block/value side:
+The historical parser architecture was strong on the rule/block/value side:
 
 - tokenization is real and deterministic
 - stylesheet parsing is AST-oriented
 - compatibility projection is explicit and no longer the parser contract
 
-However, selector handling still relies on a narrow compatibility adapter:
+At the time, selector handling still relied on a narrow compatibility adapter:
 
 - `CompatSelector` only models universal, type, id, and class selectors
 - selector parsing for the cascade path is projection logic, not syntax-layer
@@ -45,11 +56,11 @@ However, selector handling still relies on a narrow compatibility adapter:
 This issue exists to make selector syntax first-class in the syntax layer
 without dragging cascade semantics into the parser.
 
-## Goals
+## Original goals
 
-- introduce syntax-layer selector structures separate from `CompatSelector`
-- parse qualified-rule preludes into explicit selector syntax representations
-  where supported
+- introduce selector structures separate from `CompatSelector`
+- parse qualified-rule preludes into explicit selector representations where
+  supported
 - preserve unsupported selector syntax deterministically for recovery and later
   expansion
 - keep selector parsing lexical/syntactic rather than DOM-matching or
@@ -64,18 +75,20 @@ without dragging cascade semantics into the parser.
 - cascade or specificity redesign beyond the compatibility projection boundary
 - computed-style or value-parsing work
 
-## Preferred Direction
+## Superseded preferred direction
 
 Preferred architecture:
 
 1. qualified rules continue to own preserved prelude/component-value structure
-2. the syntax layer adds explicit selector-list and selector-node structures
-3. supported selector syntax projects into those structures during parsing
+2. `css::selectors` consumes those values and owns selector-list and selector
+   node structures
+3. supported selector syntax produces typed selector IR during model
+   integration
 4. unsupported selector syntax remains recoverable and deterministic
 5. compatibility projection into `CompatSelector` remains separate and
    migration-scoped
 
-## Exit Criteria
+## Historical exit criteria
 
 - syntax-layer selector structures exist in code
 - qualified-rule parsing exposes selector syntax more explicitly than raw

--- a/docs/css/o1-rule-value-model-architecture.md
+++ b/docs/css/o1-rule-value-model-architecture.md
@@ -97,7 +97,8 @@ The architectural boundary is:
    - does not own selector matching, cascade winner resolution, or computed
      values
 3. Later CSS semantics
-   - selector AST refinement and selector matching
+   - selector matching and broader selector coverage over the existing
+     `css::selectors` AST
    - at-rule interpretation such as `@media` / `@supports`
    - cascade order and winner selection
    - inheritance, specified values, computed values, and layout-facing
@@ -290,7 +291,7 @@ Purely syntactic in Milestone O:
 
 Semantic interpretation deferred to later milestones:
 
-- selector AST semantics and DOM matching
+- DOM matching over the existing selector AST
 - specificity calculation as a selector-system contract
 - shorthand expansion
 - longhand alias handling beyond basic name canonicalization

--- a/docs/css/o8-cssom-contract-and-legacy-retirement.md
+++ b/docs/css/o8-cssom-contract-and-legacy-retirement.md
@@ -81,7 +81,8 @@ The authoritative details live in:
 Milestone O does not complete later CSS semantics. The following remain
 intentional follow-up work:
 
-- selector AST expansion beyond preserved selector/prelude payloads
+- broader selector coverage and matching beyond the current `css::selectors`
+  AST/parser subset
 - selector matching beyond the current compatibility-scoped subset
 - at-rule semantic interpretation
 - cascade winner resolution that natively consumes model selectors/values

--- a/docs/css/p2-selector-ir-data-structures.md
+++ b/docs/css/p2-selector-ir-data-structures.md
@@ -1,7 +1,7 @@
 # P2: Introduce Selector IR Data Structures
 
 Last updated: 2026-04-09  
-Status: complete
+Status: complete; integrated by subsequent Milestone P work
 
 This document records the implementation of Milestone P issue P2:
 introducing the production selector intermediate representation (IR) data
@@ -74,7 +74,8 @@ Repository status:
 
 - the P2 selector IR data-structures issue is complete and may be treated as
   closed
-- the next Milestone P work should parse structured syntax-layer preludes into
-  this IR and wire `SelectorListParseResult` into the rule/model path
+- the P2 IR remains the permanent selector foundation consumed by later work
+- subsequent Milestone P issues parse structured syntax-layer preludes into this
+  IR and wire `SelectorListParseResult` into the rule/model path
 - matching and cascade winner resolution remain intentionally out of scope for
-  that next parser/model integration step
+  P2 and are separate downstream consumers

--- a/docs/css/p3-selector-parser-core-subset.md
+++ b/docs/css/p3-selector-parser-core-subset.md
@@ -1,7 +1,7 @@
 # P3: Implement Selector Parser (Core Subset)
 
 Last updated: 2026-04-09  
-Status: complete
+Status: complete; integrated by subsequent Milestone P work
 
 This document records the implementation of Milestone P issue P3:
 introducing the core selector parser that converts syntax-layer selector
@@ -86,7 +86,8 @@ P3 is complete when:
 Repository status:
 
 - the P3 core selector-parser issue is complete and may be treated as closed
-- the next Milestone P work should wire `SelectorListParseResult` into the
+- the P3 parser remains the permanent selector parser consumed by later work
+- subsequent Milestone P issues wire `SelectorListParseResult` into the
   stylesheet rule/model path
 - selector matching and cascade winner resolution remain intentionally out of
-  scope for that integration step
+  scope for P3 and are separate downstream consumers

--- a/docs/css/p4-specificity-calculation.md
+++ b/docs/css/p4-specificity-calculation.md
@@ -91,7 +91,8 @@ P4 is complete when:
 Repository status:
 
 - the P4 specificity issue is complete and may be treated as closed
-- the next Milestone P work should wire selector parse results into the
+- subsequent Milestone P work integrated selector parse results through the
   stylesheet rule/model path
-- selector matching and cascade winner resolution remain intentionally out of
-  scope for that step
+- selector matching and cascade winner resolution remain separate downstream
+  consumers; AF2 has since reconciled selector diagnostics at the model
+  boundary

--- a/docs/css/p5-invalid-selector-handling.md
+++ b/docs/css/p5-invalid-selector-handling.md
@@ -106,7 +106,8 @@ Repository status:
 
 - the P5 invalid-selector-handling issue is complete and may be treated as
   closed
-- the next Milestone P work should wire selector parse results into the
+- subsequent Milestone P work integrated selector parse results through the
   stylesheet rule/model path
-- selector matching and cascade winner resolution remain intentionally out of
-  scope for that step
+- selector matching and cascade winner resolution remain separate downstream
+  consumers; AF2 has since reconciled selector diagnostics at the model
+  boundary

--- a/docs/css/p6-unsupported-selector-handling.md
+++ b/docs/css/p6-unsupported-selector-handling.md
@@ -30,7 +30,10 @@ Syntactically valid but unsupported selectors are:
 - treated as non-matchable for the current engine stage
 - classified by explicit `UnsupportedSelectorFeature` categories
 - normalized into stable first-encounter feature order with deduplication
-- kept eligible for future support without reparsing raw stylesheet text
+- retained with its source span and unsupported feature categories for
+  diagnostics and future tracking; because this is not a lossless unsupported
+  selector AST, future support may require reparsing the preserved
+  source/prelude
 
 The in-code handling strategy is exposed as
 `UnsupportedSelectorHandling::PreserveAsUnsupported`.
@@ -110,7 +113,7 @@ Repository status:
 
 - the P6 unsupported-selector-handling issue is complete and may be treated as
   closed
-- the next Milestone P work should wire selector parse results into the
-  stylesheet rule/model path
-- selector matching and cascade winner resolution remain intentionally out of
-  scope for that step
+- Milestone P and AF2 now provide the permanent selector/model parse-result
+  path and selector diagnostic projection
+- selector matching and cascade winner resolution remain separate downstream
+  consumers

--- a/docs/css/p7-selector-serialization-debug-output.md
+++ b/docs/css/p7-selector-serialization-debug-output.md
@@ -81,7 +81,8 @@ P7 is complete when:
 Repository status:
 
 - the P7 selector-serialization issue is complete and may be treated as closed
-- the next Milestone P work should wire selector parse results into the
+- subsequent Milestone P work integrated selector parse results through the
   stylesheet rule/model path
-- selector matching and cascade winner resolution remain intentionally out of
-  scope for that step
+- selector matching and cascade winner resolution remain separate downstream
+  consumers; AF2 has since reconciled selector diagnostics at the model
+  boundary

--- a/docs/css/syntax-parser-contract.md
+++ b/docs/css/syntax-parser-contract.md
@@ -71,6 +71,17 @@ Milestone N keeps the current crate and runtime topology:
    - remains the high-level integration point that merges stylesheet results
      into the page state
 
+### Current Post-N Selector Ownership
+
+The following ownership is part of the later repository architecture, not a
+Milestone N responsibility. Subsequent Milestone P work introduced
+`css::selectors` as the permanent selector-specific AST/parser owner, and AF2
+reconciles that architecture with the current Milestone AF contract.
+
+`css::selectors` consumes structured `css::syntax` output and owns the
+permanent selector AST/parser, selector support policy, and selector semantics.
+`css::syntax` intentionally does not own a second selector AST.
+
 ## Implementation Status
 
 Milestone N is complete.
@@ -269,7 +280,9 @@ Authoritative handoff rule:
 The Milestone N parser foundation is intentionally incomplete in the following
 areas:
 
-- selector syntax is not yet fully represented as a dedicated syntax-layer AST
+- broader selector grammar and matching coverage remain incomplete, but
+  selector-specific AST/parser ownership is resolved in `css::selectors`; a
+  second selector AST inside `css::syntax` is intentionally not planned
 - compatibility selector projection still exists for the current cascade layer
 - at-rule parsing is structural rather than semantics-complete
 - declaration values are preserved as generic syntax component values rather
@@ -394,32 +407,29 @@ Downstream milestones may assume:
 - malformed CSS does not crash the engine
 
 Downstream milestones must not assume:
-- selector parsing is final
+- selector matching or broad selector coverage is complete
 - at-rule parsing is complete
 - current compatibility structs are the permanent syntax AST
 - syntax parsing performs cascade or computed-style work
 
 ## Related Next Steps And References
 
-The next queued syntax-layer follow-ups after Milestone N are:
+The remaining syntax-layer follow-ups after Milestone N are:
 
-- [`docs/css/n9-selector-structure-expansion.md`](n9-selector-structure-expansion.md)
 - [`docs/css/n2b-incremental-line-record-maintenance.md`](n2b-incremental-line-record-maintenance.md)
+
+Selector AST/parser ownership has been fulfilled outside the generic syntax
+layer by Milestone P and AF2. `css::selectors` consumes structured syntax-layer
+component values and owns selector-specific AST, support policy, diagnostics,
+and snapshots. A second selector AST under `css::syntax` is not planned.
 
 Historical reference:
 
 - [`docs/css/n2a-decouple-structured-parse-results.md`](n2a-decouple-structured-parse-results.md)
   is now subsumed by `n4-structured-syntax-ast.md`
-- selector-structure expansion was initially queued in-repo under `N5` and was
-  renumbered to `N6` once deterministic parse recovery became the implemented
-  `N5`
-- selector-structure expansion was then renumbered to `N7` once stable
-  debug/serialization output became the implemented `N6`
-- selector-structure expansion was then renumbered again to `N8` once resource
-  limits and parser invariants became the implemented `N7`
-- selector-structure expansion was then renumbered again to
-  [`docs/css/n9-selector-structure-expansion.md`](n9-selector-structure-expansion.md)
-  once parser contract cutover/documentation became the implemented `N8`
+- the original N9 selector-structure proposal is retained as historical
+  context in [`docs/css/n9-selector-structure-expansion.md`](n9-selector-structure-expansion.md)
+  and is superseded by the Milestone P selector architecture
 
 Related reference for the N2 source/token layer:
 
@@ -449,7 +459,7 @@ Related reference for the N8 cutover/completion work:
 
 - [`docs/css/n8-parser-contract-cutover.md`](n8-parser-contract-cutover.md)
 
-Related reference for the next selector-structure expansion work:
+Historical reference for the proposed selector-structure expansion work:
 
 - [`docs/css/n9-selector-structure-expansion.md`](n9-selector-structure-expansion.md)
 

--- a/docs/engine-feature-gap-tracker.md
+++ b/docs/engine-feature-gap-tracker.md
@@ -127,6 +127,14 @@ Milestone AF foundation status:
   pseudo-classes, pseudo-elements, `:has()`, and fine-grained subtree
   invalidation for later CSS-owned AF work. Browser/runtime must consume the
   future richer plan without learning selector semantics.
+- AF2 completes the existing Milestone P selector AST/parser foundation and
+  adds CSS-owned selector diagnostic normalization plus model-boundary
+  projection into the shared syntax diagnostic transport. AF2 does not claim
+  broad selector coverage, pseudo-class or pseudo-element support, namespace
+  selectors, selector matching conformance, selector dependency invalidation,
+  media queries, custom properties, animations, transitions, CSSOM,
+  `getComputedStyle()`, or JavaScript-facing style mutation; see
+  `docs/css/af2-selector-ast-and-parser.md`.
 
 Major missing families remain:
 


### PR DESCRIPTION
Resolves #1079 